### PR TITLE
[AI] Add cross-backend SIMD regression tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,3 +19,27 @@ rustflags = ["-C", "target-feature=+simd128"]
 #[target.aarch64-unknown-linux-gnu]
 #runner = "qemu-aarch64 -cpu neoverse-n2 -L /usr/aarch64-linux-gnu"
 #linker = "aarch64-linux-gnu-gcc"
+
+# Cross-arch test execution under QEMU user-mode emulation, no physical
+# hardware needed - `cargo test --target <one of these>` just works given
+# `qemu-user` on PATH and the target added via `rustup target add`. Musl
+# (not gnu) targets are used deliberately: their self-contained runtime lets
+# `rust-lld` (bundled with rustc) link a fully static binary without a
+# separate cross-gcc/cross-libc, which a `-gnu` target would need. `rust-lld`
+# replaces the host's `cc`/`ld.bfd`, which chokes on target-specific link
+# flags (e.g. aarch64's `--fix-cortex-a53-843419`). `+crt-static` is musl's
+# default anyway, but is set explicitly since omitting it made
+# riscv64gc-unknown-linux-musl fail to link with "unable to find library
+# -lgcc_s" (it otherwise pulls in a dynamic unwind stub that doesn't exist
+# for a static musl target).
+[target.aarch64-unknown-linux-musl]
+runner = "qemu-aarch64"
+rustflags = ["-C", "linker-flavor=ld.lld", "-C", "linker=rust-lld", "-C", "target-feature=+crt-static"]
+
+[target.armv7-unknown-linux-musleabihf]
+runner = "qemu-arm"
+rustflags = ["-C", "linker-flavor=ld.lld", "-C", "linker=rust-lld", "-C", "target-feature=+crt-static"]
+
+[target.riscv64gc-unknown-linux-musl]
+runner = "qemu-riscv64"
+rustflags = ["-C", "linker-flavor=ld.lld", "-C", "linker=rust-lld", "-C", "target-feature=+crt-static"]

--- a/justfile
+++ b/justfile
@@ -1,0 +1,118 @@
+set export := true
+
+# All test recipes target --lib: the workspace members (app, speedtest,
+# pic-scale-js, wasm) are demo/binding crates with their own build
+# requirements, not part of the library under test.
+
+## native
+
+# Default feature set (neon, rdm, sse, avx, threading) on this host.
+test:
+    cargo test --lib
+
+# Every optional feature enabled together.
+test-all-features:
+    cargo test --lib --all-features
+
+# Isolates each SIMD tier the way CI's `tests_x86` job does, so a bug gated
+# behind one feature doesn't hide behind another (matches build_push.yml).
+test-x86-matrix:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for feature in avx sse "" nightly_f16; do
+        echo "=== features: '${feature}' ==="
+        cargo test --lib --features "${feature}"
+    done
+
+# Needs an AVX-512 host; CI covers this on a real ARM/x86 runner instead of
+# qemu, since narrowing AVX-512 subsets under emulation isn't set up here.
+test-avx512:
+    cargo test --lib --features avx512
+
+## cross-arch (QEMU user-mode emulation, no physical hardware needed)
+# One-time setup: `just install-cross-targets`, then `apt-get install qemu-user`.
+# Runner + linker flags live in .cargo/config.toml (rust-lld + +crt-static,
+# since the host cc/ld.bfd chokes on target-specific link flags and
+# riscv64gc-musl otherwise fails to link with "unable to find library -lgcc_s").
+
+# NEON module is aarch64-only (see src/lib.rs). Includes nightly_f16 for full
+# coverage - note `neon::rgba_f16::backend_comparison_tests::neon_row_matches_scalar_reference`
+# currently aborts the whole binary (SIGABRT) under qemu-aarch64: a real
+# out-of-bounds read in `convolve_horizontal_rgba_neon_row_one_f16`
+# (off-by-one loop bound), not a qemu/harness issue. Use `test-aarch64-safe`
+# to see the rest of the suite's results until that's fixed.
+test-aarch64:
+    cargo test --target aarch64-unknown-linux-musl --no-default-features --features "neon,rdm,nightly_f16" --lib
+
+# Same as test-aarch64 but skips the test that currently crashes the process.
+test-aarch64-safe:
+    cargo test --target aarch64-unknown-linux-musl --no-default-features --features "neon,rdm,nightly_f16" --lib -- --skip neon::rgba_f16::backend_comparison_tests::neon_row_matches_scalar_reference
+
+# No arch-specific SIMD features exist for 32-bit ARM in this crate - this
+# exercises the portable scalar path, which CI doesn't build or test at all.
+test-armv7:
+    cargo test --target armv7-unknown-linux-musleabihf --no-default-features --lib
+
+# CI only `cargo build`s this target; this actually runs the suite.
+test-riscv64:
+    cargo test --target riscv64gc-unknown-linux-musl --no-default-features --lib
+
+# Uses the -safe aarch64 variant so one known crash doesn't stop armv7/riscv64
+# from running too; use `just test-aarch64` directly to reproduce the crash.
+test-cross: test-aarch64-safe test-armv7 test-riscv64
+
+## everything
+
+test-all: test test-x86-matrix test-avx512 test-cross
+    @echo "All test suites passed."
+
+## miri (undefined-behavior detection)
+# One-time setup: `just miri-setup`. Miri interprets MIR directly, so it can
+# cross-check aarch64 NEON code on this x86_64 host with no qemu/hardware -
+# but its NEON intrinsic coverage has real gaps (see miri-neon below).
+
+miri-setup:
+    rustup component add miri
+    cargo +nightly miri setup
+    cargo +nightly miri setup --target aarch64-unknown-linux-gnu
+
+# Native x86_64: SSE/AVX2/AVX-512. Miri fully supports these intrinsics, so
+# this is a reliable "no known UB" gate - clean as of this writing. Excludes
+# nightly_f16: those tests are technically correct under Miri but so slow
+# (minutes per test - heavy scalar f16 bit-twiddling interpreted one op at a
+# time) that they aren't practical for a routine check.
+miri:
+    cargo +nightly miri test --lib -- backend_comparison_tests
+    cargo +nightly miri test --lib --features avx512 -- avx512::
+
+# Best-effort NEON, cross-interpreted via Miri (no ARM hardware/qemu needed).
+# Runs one module at a time and keeps going past failures - unlike plain
+# `cargo miri test`, which aborts the WHOLE run on the first hit of either a
+# real bug or an unsupported intrinsic, hiding every module after it.
+#
+# Two distinct outcomes, do not conflate them:
+#   - "error: Undefined Behavior: ..."     -> a REAL bug (see BACKEND_COMPARISON_FINDINGS.md).
+#   - "error: unsupported operation: ..."  -> a Miri tooling gap (missing NEON
+#     intrinsic support, e.g. urshl/sqshrun/faddv), NOT a bug - that module
+#     just can't be checked this way.
+#
+# Confirmed real UB so far: rgba_u8/rgb_u8/plane_u8/cbcr8 (misaligned pointer
+# cast in the shared tail-pixel-load helpers in neon/utils.rs), rgb_f32
+# (Stacked Borrows violation, src/neon/rgb_f32.rs:76), vertical_f32
+# (genuine out-of-bounds read for narrow row widths, src/neon/vertical_f32.rs).
+# This is a representative sample, not an exhaustive sweep - expect this to
+# take a long time (many minutes) if extended to every neon/*.rs file.
+miri-neon:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    modules="alpha_f32 rgba_f32 rgb_f32 plane_f32 vertical_f32 rgba_u8 rgb_u8 plane_u8 cbcr8 rgba_u16 rgb_u16 plane_u16 alpha_u16 vertical_u8 vertical_u16"
+    for m in $modules; do
+        echo "=== neon::${m} ==="
+        timeout 120 cargo +nightly miri test --target aarch64-unknown-linux-gnu --no-default-features --features "neon,rdm" --lib -- "neon::${m}::" 2>&1 \
+            | grep -E "^running|\.\.\. ok$|\.\.\. ignored|error: Undefined Behavior|error: unsupported|test result" || true
+    done
+
+## setup
+
+install-cross-targets:
+    rustup target add aarch64-unknown-linux-musl armv7-unknown-linux-musleabihf riscv64gc-unknown-linux-musl

--- a/src/avx2/alpha_f16.rs
+++ b/src/avx2/alpha_f16.rs
@@ -190,3 +190,84 @@ fn avx_unpremultiply_alpha_rgba_f16_row_impl(in_place: &mut [f16]) {
         unpremultiply_pixel_f16_row(rem);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close};
+
+    // f16 has only ~10 bits of mantissa, so the f32-domain rounding
+    // differences between the scalar reference and the AVX2 (f16<->f32
+    // conversion + multiply/divide) path can move the result by roughly one
+    // f16 ULP. Random alpha is kept away from 0 (see `make_rgba`) so
+    // unpremultiply's relative error stays small in absolute terms too.
+    const ATOL: f32 = 1e-3;
+
+    /// Builds an RGBA f16 buffer in `[0, 1)` that mixes alpha == 0, alpha == 1
+    /// and fully random pixels (with random alpha kept away from 0) so both
+    /// the vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<f16> {
+        let mut buf = rng.fill_f16_unit(pixels * 4);
+        for chunk in buf.as_chunks_mut::<4>().0 {
+            chunk[3] = (0.05 + 0.95 * chunk[3] as f32) as f16;
+        }
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0.;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 1.;
+        }
+        buf
+    }
+
+    fn has_avx2_f16c() -> bool {
+        is_x86_feature_detected!("avx2") && is_x86_feature_detected!("f16c")
+    }
+
+    #[test]
+    fn avx2_premultiply_matches_scalar_reference() {
+        if !has_avx2_f16c() {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0f16; pixels * 4];
+            let mut dst_avx = vec![0f16; pixels * 4];
+            premultiply_pixel_f16_row(&mut dst_scalar, &src);
+            avx_premultiply_alpha_rgba_f16(&mut dst_avx, &src);
+
+            assert_f16_slices_close(
+                &dst_avx,
+                &dst_scalar,
+                ATOL,
+                &format!("{pixels} pixels: AVX2 premultiply"),
+            );
+        }
+    }
+
+    #[test]
+    fn avx2_unpremultiply_matches_scalar_reference() {
+        if !has_avx2_f16c() {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut avx_buf = src;
+            unpremultiply_pixel_f16_row(&mut scalar_buf);
+            avx_unpremultiply_alpha_rgba_f16(&mut avx_buf);
+
+            assert_f16_slices_close(
+                &avx_buf,
+                &scalar_buf,
+                ATOL,
+                &format!("{pixels} pixels: AVX2 unpremultiply"),
+            );
+        }
+    }
+}

--- a/src/avx2/alpha_f32.rs
+++ b/src/avx2/alpha_f32.rs
@@ -221,3 +221,83 @@ fn avx_premultiply_alpha_rgba_f32_row_impl(dst: &mut [f32], src: &[f32]) {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::alpha_handle_f32::{premultiply_rgba_f32_row, unpremultiply_rgba_f32_row};
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    // Premultiply is a plain per-lane multiply with no reassociation, so it
+    // is bit-exact against the scalar reference. Unpremultiply is not: the
+    // scalar reference computes `1. / a` and then multiplies, while AVX2
+    // does a direct division - mathematically the same but rounded
+    // differently, so it can be off by a few ULPs. Random alpha is kept
+    // away from 0 (see `make_rgba`) so that relative error stays small in
+    // absolute terms too.
+    const ATOL: f32 = 1e-4;
+
+    /// Builds an RGBA f32 buffer in `[0, 1)` that mixes alpha == 0, alpha == 1
+    /// and fully random pixels (with random alpha kept away from 0) so both
+    /// the vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<f32> {
+        let mut buf = rng.fill_f32_unit(pixels * 4);
+        for chunk in buf.as_chunks_mut::<4>().0 {
+            chunk[3] = 0.05 + 0.95 * chunk[3];
+        }
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0.;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 1.;
+        }
+        buf
+    }
+
+    #[test]
+    fn avx2_premultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0f32; pixels * 4];
+            let mut dst_avx = vec![0f32; pixels * 4];
+            premultiply_rgba_f32_row(&mut dst_scalar, &src);
+            avx_premultiply_alpha_rgba_f32(&mut dst_avx, &src);
+
+            assert_f32_slices_close(
+                &dst_avx,
+                &dst_scalar,
+                ATOL,
+                &format!("{pixels} pixels: AVX2 premultiply"),
+            );
+        }
+    }
+
+    #[test]
+    fn avx2_unpremultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut avx_buf = src;
+            unpremultiply_rgba_f32_row(&mut scalar_buf);
+            avx_unpremultiply_alpha_rgba_f32(&mut avx_buf);
+
+            assert_f32_slices_close(
+                &avx_buf,
+                &scalar_buf,
+                ATOL,
+                &format!("{pixels} pixels: AVX2 unpremultiply"),
+            );
+        }
+    }
+}

--- a/src/avx2/alpha_u16.rs
+++ b/src/avx2/alpha_u16.rs
@@ -468,3 +468,73 @@ fn avx_unpremultiply_alpha_rgba_u16_row_avx(in_place: &mut [u16], bit_depth: usi
         rem.copy_from_slice(&dst_buffer[..rem.len()]);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::alpha_handle_u16::{premultiply_alpha_rgba_row, unpremultiply_alpha_rgba_row};
+    use crate::test_utils::XorShiftRng;
+
+    /// Builds an RGBA16 buffer (values clamped to `bit_depth`) that mixes
+    /// alpha == 0, alpha == max and fully random pixels, so both the
+    /// vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize, bit_depth: usize) -> Vec<u16> {
+        let max_colors = ((1u32 << bit_depth) - 1) as u16;
+        let mut buf = rng.fill_u16(pixels * 4, max_colors);
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = max_colors;
+        }
+        buf
+    }
+
+    #[test]
+    fn avx2_premultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for bit_depth in [10usize, 12, 16, 14] {
+            for pixels in [1usize, 4, 17, 256] {
+                let mut rng = XorShiftRng::new(0xA11CE ^ (bit_depth as u64) << 32 ^ pixels as u64);
+                let src = make_rgba(&mut rng, pixels, bit_depth);
+
+                let mut dst_scalar = vec![0u16; pixels * 4];
+                let mut dst_avx = vec![0u16; pixels * 4];
+                premultiply_alpha_rgba_row(&mut dst_scalar, &src, bit_depth);
+                avx_premultiply_alpha_rgba_u16(&mut dst_avx, &src, bit_depth);
+
+                assert_eq!(
+                    dst_scalar, dst_avx,
+                    "bit_depth {bit_depth}, {pixels} pixels: AVX2 premultiply diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: zeroes RGB when alpha==0, but the scalar u16 unpremultiply path leaves RGB untouched in that case (u8 scalar path does zero it - inconsistent across bit depths) - see issue"]
+    #[test]
+    fn avx2_unpremultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for bit_depth in [10usize, 12, 16, 14] {
+            for pixels in [1usize, 4, 17, 256] {
+                let mut rng = XorShiftRng::new(0xB0BA ^ (bit_depth as u64) << 32 ^ pixels as u64);
+                let src = make_rgba(&mut rng, pixels, bit_depth);
+
+                let mut scalar_buf = src.clone();
+                let mut avx_buf = src;
+                unpremultiply_alpha_rgba_row(&mut scalar_buf, bit_depth);
+                avx_unpremultiply_alpha_rgba_u16(&mut avx_buf, bit_depth);
+
+                assert_eq!(
+                    scalar_buf, avx_buf,
+                    "bit_depth {bit_depth}, {pixels} pixels: AVX2 unpremultiply diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/alpha_u8.rs
+++ b/src/avx2/alpha_u8.rs
@@ -329,3 +329,94 @@ fn avx_unpremultiply_alpha_rgba_impl_row(in_place: &mut [u8], executor: impl Dis
         executor.disassociate(in_place);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::WorkloadStrategy;
+    use crate::alpha_handle_u8::{
+        premultiply_alpha_rgba_row_impl, unpremultiply_alpha_rgba_row_impl,
+    };
+    use crate::test_utils::XorShiftRng;
+
+    /// Builds an RGBA8 buffer that mixes alpha == 0, alpha == 255 and fully
+    /// random pixels so both the vectorized bulk path and the scalar tail
+    /// remainder exercise the branches the premultiply/unpremultiply math
+    /// takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<u8> {
+        let mut buf = rng.fill_u8(pixels * 4);
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 255;
+        }
+        buf
+    }
+
+    #[ignore = "known bug: div_by_255 rounding formula uses +127 instead of +128 on one term, diverges from the scalar reference for part of the u8*u8 product range - see issue"]
+    #[test]
+    fn avx2_premultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0u8; pixels * 4];
+            let mut dst_avx = vec![0u8; pixels * 4];
+            premultiply_alpha_rgba_row_impl(&mut dst_scalar, &src);
+            avx_premultiply_alpha_rgba(&mut dst_avx, &src);
+
+            assert_eq!(
+                dst_scalar, dst_avx,
+                "{pixels} pixels: AVX2 premultiply diverges from the scalar reference"
+            );
+        }
+    }
+
+    #[ignore = "known bug: uses an approximate reciprocal (_mm_rcp_ps/_mm256_rcp_ps) instead of exact division like the scalar reference - see issue"]
+    #[test]
+    fn avx2_unpremultiply_quality_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut avx_buf = src;
+            unpremultiply_alpha_rgba_row_impl(&mut scalar_buf);
+            avx_unpremultiply_alpha_rgba(&mut avx_buf, WorkloadStrategy::PreferQuality);
+
+            assert_eq!(
+                scalar_buf, avx_buf,
+                "{pixels} pixels: AVX2 unpremultiply (PreferQuality) diverges from the scalar reference"
+            );
+        }
+    }
+
+    #[ignore = "known bug: uses an approximate reciprocal (_mm_rcp_ps/_mm256_rcp_ps) instead of exact division like the scalar reference - see issue"]
+    #[test]
+    fn avx2_unpremultiply_speed_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xC0DE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut avx_buf = src;
+            unpremultiply_alpha_rgba_row_impl(&mut scalar_buf);
+            avx_unpremultiply_alpha_rgba(&mut avx_buf, WorkloadStrategy::PreferSpeed);
+
+            assert_eq!(
+                scalar_buf, avx_buf,
+                "{pixels} pixels: AVX2 unpremultiply (PreferSpeed) diverges from the scalar reference"
+            );
+        }
+    }
+}

--- a/src/avx2/horizontal_ar30.rs
+++ b/src/avx2/horizontal_ar30.rs
@@ -481,3 +481,170 @@ impl<const AR_TYPE: usize, const AR_ORDER: usize> Row1ExecutionUnit<AR_TYPE, AR_
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::factory::{Ar30ByteOrder, Rgb30};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    /// AR30 is a packed 10-10-10-2 format with no separate per-channel byte
+    /// layout, so `handler_provider`'s scalar row-convolution reference (which
+    /// operates on flat `u8` channel arrays) doesn't apply here. Rebuild the
+    /// same math directly on top of the crate's own `Rgb30::unpack`/`pack_w_a`,
+    /// using the identical Q15 weights (`support::PRECISION`) and rounding the
+    /// AVX2 kernel uses.
+    fn scalar_reference_ar30_row<const AR_TYPE: usize, const AR_ORDER: usize>(
+        src: &[u8],
+        dst: &mut [u8],
+        filter_weights: &FilterWeights<i16>,
+    ) {
+        const PRECISION: i32 = 15;
+        const ROUNDING: i32 = 1 << (PRECISION - 1);
+        let rgb_type: Rgb30 = AR_TYPE.into();
+
+        for (dst_chunk, (&bounds, weights)) in dst.as_chunks_mut::<4>().0.iter_mut().zip(
+            filter_weights
+                .bounds
+                .iter()
+                .zip(filter_weights.weights.chunks_exact(filter_weights.aligned_size)),
+        ) {
+            let mut acc_r = ROUNDING;
+            let mut acc_g = ROUNDING;
+            let mut acc_b = ROUNDING;
+            for (k, &weight) in weights.iter().enumerate().take(bounds.size) {
+                let w = weight as i32;
+                let px = (bounds.start + k) * 4;
+                let word = u32::from_ne_bytes(src[px..px + 4].try_into().unwrap());
+                let (r, g, b, _a) = rgb_type.unpack::<AR_ORDER>(word);
+                acc_r += r as i32 * w;
+                acc_g += g as i32 * w;
+                acc_b += b as i32 * w;
+            }
+            let r = (acc_r >> PRECISION).clamp(0, 1023);
+            let g = (acc_g >> PRECISION).clamp(0, 1023);
+            let b = (acc_b >> PRECISION).clamp(0, 1023);
+            let packed = rgb_type.pack_w_a::<AR_ORDER>(r, g, b, 3);
+            dst_chunk.copy_from_slice(&packed.to_ne_bytes());
+        }
+    }
+
+    fn make_ar30_src<const AR_ORDER: usize>(
+        rgb_type: Rgb30,
+        rng: &mut XorShiftRng,
+        pixel_count: usize,
+    ) -> Vec<u8> {
+        let components = rng.fill_u16(pixel_count * 3, 1023);
+        let mut out = Vec::with_capacity(pixel_count * 4);
+        for chunk in components.as_chunks::<3>().0 {
+            let packed =
+                rgb_type.pack_w_a::<AR_ORDER>(chunk[0] as i32, chunk[1] as i32, chunk[2] as i32, 3);
+            out.extend_from_slice(&packed.to_ne_bytes());
+        }
+        out
+    }
+
+    fn run_row_test<const AR_TYPE: usize, const AR_ORDER: usize>(label: &str) {
+        let rgb_type: Rgb30 = AR_TYPE.into();
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = make_ar30_src::<AR_ORDER>(rgb_type, &mut rng, in_size);
+
+                let mut dst_scalar = vec![0u8; out_size * 4];
+                let mut dst_avx = vec![0u8; out_size * 4];
+                scalar_reference_ar30_row::<AR_TYPE, AR_ORDER>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                );
+                avx_convolve_horizontal_rgba_rows_ar30::<AR_TYPE, AR_ORDER>(
+                    &src,
+                    &mut dst_avx,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx,
+                    "{label} {resampling:?} {in_size}->{out_size}: AVX2 AR30 single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    fn run_rows_4_test<const AR_TYPE: usize, const AR_ORDER: usize>(label: &str) {
+        let rgb_type: Rgb30 = AR_TYPE.into();
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = make_ar30_src::<AR_ORDER>(rgb_type, &mut rng, in_size * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_avx = vec![0u8; dst_stride * ROWS];
+                for row in 0..ROWS {
+                    scalar_reference_ar30_row::<AR_TYPE, AR_ORDER>(
+                        &src[row * src_stride..],
+                        &mut dst_scalar[row * dst_stride..(row + 1) * dst_stride],
+                        &filter_weights,
+                    );
+                }
+                avx_convolve_horizontal_rgba_rows_4_ar30::<AR_TYPE, AR_ORDER>(
+                    &src,
+                    src_stride,
+                    &mut dst_avx,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx,
+                    "{label} {resampling:?} {in_size}->{out_size}: AVX2 AR30 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_row_test::<{ Rgb30::Ar30 as usize }, { Ar30ByteOrder::Host as usize }>("AR30 host");
+        run_row_test::<{ Rgb30::Ar30 as usize }, { Ar30ByteOrder::Network as usize }>(
+            "AR30 network",
+        );
+        run_row_test::<{ Rgb30::Ra30 as usize }, { Ar30ByteOrder::Host as usize }>("RA30 host");
+        run_row_test::<{ Rgb30::Ra30 as usize }, { Ar30ByteOrder::Network as usize }>(
+            "RA30 network",
+        );
+    }
+
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_rows_4_test::<{ Rgb30::Ar30 as usize }, { Ar30ByteOrder::Host as usize }>("AR30 host");
+        run_rows_4_test::<{ Rgb30::Ar30 as usize }, { Ar30ByteOrder::Network as usize }>(
+            "AR30 network",
+        );
+        run_rows_4_test::<{ Rgb30::Ra30 as usize }, { Ar30ByteOrder::Host as usize }>("RA30 host");
+        run_rows_4_test::<{ Rgb30::Ra30 as usize }, { Ar30ByteOrder::Network as usize }>(
+            "RA30 network",
+        );
+    }
+}

--- a/src/avx2/plane_f32.rs
+++ b/src/avx2/plane_f32.rs
@@ -448,3 +448,117 @@ fn convolve_horizontal_plane_avx_rows_4_impl<const FMA: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32,
+    };
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // Same reduction-reordering rationale as sse/plane_f32.rs (and the
+    // rgba_f32.rs AVX2 default/FMA cases): a single-channel plane accumulates
+    // multiple taps per SIMD lane and horizontally reduces at the end, unlike
+    // the scalar loop's strict left-to-right accumulation - not bit-exact.
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn avx2_default_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_plane_avx_row_one_f32_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_row_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_plane_avx_row_one_f32_fma, "AVX2 FMA");
+    }
+
+    fn run_row_comparison(
+        simd_fn: fn(&[f32], &mut [f32], &FilterWeights<f32>, u32),
+        label: &str,
+    ) {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size);
+
+                let mut dst_scalar = vec![0f32; out_size];
+                let mut dst_simd = vec![0f32; out_size];
+                convolve_horizontal_native_row_f32::<1>(&src, &mut dst_scalar, &filter_weights, 8);
+                simd_fn(&src, &mut dst_simd, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_default_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_plane_avx_rows_4_f32_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_rows_4_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_plane_avx_rows_4_f32_fma, "AVX2 FMA");
+    }
+
+    fn run_rows_4_comparison(
+        simd_fn: fn(&[f32], usize, &mut [f32], usize, &FilterWeights<f32>, u32),
+        label: &str,
+    ) {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_simd = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, src_stride, &mut dst_simd, dst_stride, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/plane_f32_f64.rs
+++ b/src/avx2/plane_f32_f64.rs
@@ -351,3 +351,136 @@ impl<const FMA: bool> Row4ExecutionUnit<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_4_row_f32_f64, convolve_horizontal_native_row_f32_f64,
+    };
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    /// `PreferQuality` weights are computed in `f64` (see
+    /// `HorizontalFilterPass<f32, f64, CN>` in `src/factory/*_f32.rs`), which
+    /// `test_utils::make_row_filter_weights_f32` doesn't produce - it only
+    /// builds the `f32`-weighted path. Mirror it here with the `f64` generator.
+    fn make_row_filter_weights_f64(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<f64>, PicScaleError> {
+        <f32 as WeightsGenerator<f64>>::make_weights(resampling, in_size, out_size)
+    }
+
+    // f64 weights remove the weight-quantization error the f32/f32 path has, but
+    // SIMD reduction-order still differs from the scalar accumulation order, so
+    // this isn't bit-exact either - a slightly looser tolerance than the f32/f32
+    // ATOL is warranted here.
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn avx2_default_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_row_comparison(convolve_hor_plane_avx_row_one_f32_f64_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_row_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_row_comparison(convolve_hor_plane_avx_row_one_f32_f64_fma, "AVX2 FMA");
+    }
+
+    fn run_row_comparison(
+        simd_fn: fn(&[f32], &mut [f32], &FilterWeights<f64>, u32),
+        label: &str,
+    ) {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size);
+
+                let mut dst_scalar = vec![0f32; out_size];
+                let mut dst_simd = vec![0f32; out_size];
+                convolve_horizontal_native_row_f32_f64::<1>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, &mut dst_simd, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_default_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_rows_4_comparison(convolve_hor_plane_avx_rows_4_f32_f64_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_rows_4_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_rows_4_comparison(convolve_hor_plane_avx_rows_4_f32_f64_fma, "AVX2 FMA");
+    }
+
+    fn run_rows_4_comparison(
+        simd_fn: fn(&[f32], usize, &mut [f32], usize, &FilterWeights<f64>, u32),
+        label: &str,
+    ) {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_simd = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_4_row_f32_f64::<1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, src_stride, &mut dst_simd, dst_stride, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/plane_s16_lb.rs
+++ b/src/avx2/plane_s16_lb.rs
@@ -336,3 +336,103 @@ impl<const D: bool> OneRowExecutionUnitI16<D> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    /// `plane_s16` pixels are symmetric fixed-point samples in
+    /// `[-(1 << (bit_depth - 1)), (1 << (bit_depth - 1)) - 1]` (see the `v_min_colors`/`v_max_colors`
+    /// clamp above) rather than unsigned - `XorShiftRng` has no signed fill helper, so center an
+    /// unsigned fill of the same width instead of adding one to `test_utils.rs`.
+    fn fill_i16(rng: &mut XorShiftRng, len: usize, bit_depth: u32) -> Vec<i16> {
+        let half = 1i32 << (bit_depth - 1);
+        rng.fill_u16(len, (1u16 << bit_depth) - 1)
+            .into_iter()
+            .map(|v| (v as i32 - half) as i16)
+            .collect()
+    }
+
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = fill_i16(&mut rng, in_size, BIT_DEPTH);
+
+                let mut dst_scalar = vec![0i16; out_size];
+                let mut dst_avx2 = vec![0i16; out_size];
+                convolve_row_handler_fixed_point::<i16, i32, 1>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_avx_i16lp_row(&src, &mut dst_avx2, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 plane s16 lb single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = fill_i16(&mut rng, src_stride * ROWS, BIT_DEPTH);
+
+                let mut dst_scalar = vec![0i16; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0i16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<i16, i32, 1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_avx_rows_4_i16(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 plane s16 lb 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/plane_u16.rs
+++ b/src/avx2/plane_u16.rs
@@ -424,3 +424,129 @@ impl<const FMA: bool> OneRowExecutionHandler<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_horizontal::{
+        convolve_row_handler_floating_point, convolve_row_handler_floating_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    const BIT_DEPTH: u32 = 16;
+
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size];
+                let mut dst_avx2 = vec![0u16; out_size];
+                convolve_row_handler_floating_point::<u16, f32, f32, 1>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_avx_u16_row_default(
+                    &src,
+                    &mut dst_avx2,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 plane u16 single-row (default) output diverges from the scalar reference"
+                );
+
+                if std::arch::is_x86_feature_detected!("fma") {
+                    let mut dst_avx2_fma = vec![0u16; out_size];
+                    convolve_horizontal_plane_avx_u16_row_fma(
+                        &src,
+                        &mut dst_avx2_fma,
+                        &filter_weights,
+                        BIT_DEPTH,
+                    );
+
+                    assert_eq!(
+                        dst_scalar, dst_avx2_fma,
+                        "{resampling:?} {in_size}->{out_size}: AVX2 plane u16 single-row (fma) output diverges from the scalar reference"
+                    );
+                }
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, 1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_avx_rows_4_u16_default(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 plane u16 4-row (default) output diverges from the scalar reference"
+                );
+
+                if std::arch::is_x86_feature_detected!("fma") {
+                    let mut dst_avx2_fma = vec![0u16; dst_stride * ROWS];
+                    convolve_horizontal_plane_avx_rows_4_u16_fma(
+                        &src,
+                        src_stride,
+                        &mut dst_avx2_fma,
+                        dst_stride,
+                        &filter_weights,
+                        BIT_DEPTH,
+                    );
+
+                    assert_eq!(
+                        dst_scalar, dst_avx2_fma,
+                        "{resampling:?} {in_size}->{out_size}: AVX2 plane u16 4-row (fma) output diverges from the scalar reference"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/avx2/plane_u16_lb.rs
+++ b/src/avx2/plane_u16_lb.rs
@@ -364,3 +364,91 @@ impl<const D: bool> OneRowExecutionUnit<D> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; out_size];
+                let mut dst_avx2 = vec![0u16; out_size];
+                convolve_row_handler_fixed_point::<u16, i32, 1>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_avx_u16lp_row(&src, &mut dst_avx2, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 plane u16 lb single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<u16, i32, 1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_avx_rows_4_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 plane u16 lb 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgb_f32.rs
+++ b/src/avx2/rgb_f32.rs
@@ -540,3 +540,112 @@ impl<const FMA: bool> ExecutionUnit4Row<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32};
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // Same reordering/FMA-rounding rationale as avx2/rgba_f32.rs.
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn avx2_default_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgb_avx_row_one_f32_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_row_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgb_avx_row_one_f32_fma, "AVX2 FMA");
+    }
+
+    fn run_row_comparison(
+        simd_fn: fn(&[f32], &mut [f32], &FilterWeights<f32>, u32),
+        label: &str,
+    ) {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f32; out_size * 3];
+                let mut dst_simd = vec![0f32; out_size * 3];
+                convolve_horizontal_native_row_f32::<3>(&src, &mut dst_scalar, &filter_weights, 8);
+                simd_fn(&src, &mut dst_simd, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_default_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgb_avx_rows_4_f32_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_rows_4_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgb_avx_rows_4_f32_fma, "AVX2 FMA");
+    }
+
+    fn run_rows_4_comparison(
+        simd_fn: fn(&[f32], usize, &mut [f32], usize, &FilterWeights<f32>, u32),
+        label: &str,
+    ) {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_simd = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, src_stride, &mut dst_simd, dst_stride, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgb_f32_f64.rs
+++ b/src/avx2/rgb_f32_f64.rs
@@ -349,3 +349,130 @@ impl<const FMA: bool> ExecutionUnit4Row<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_4_row_f32_f64, convolve_horizontal_native_row_f32_f64,
+    };
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    /// See the identical helper in `src/avx2/plane_f32_f64.rs` - `PreferQuality`
+    /// weights are `f64`, which `test_utils` doesn't build a helper for.
+    fn make_row_filter_weights_f64(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<f64>, PicScaleError> {
+        <f32 as WeightsGenerator<f64>>::make_weights(resampling, in_size, out_size)
+    }
+
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn avx2_default_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgb_avx_row_one_f32_f64_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_row_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgb_avx_row_one_f32_f64_fma, "AVX2 FMA");
+    }
+
+    fn run_row_comparison(
+        simd_fn: fn(&[f32], &mut [f32], &FilterWeights<f64>, u32),
+        label: &str,
+    ) {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f32; out_size * 3];
+                let mut dst_simd = vec![0f32; out_size * 3];
+                convolve_horizontal_native_row_f32_f64::<3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, &mut dst_simd, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_default_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgb_avx_rows_4_f32_f64_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_rows_4_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgb_avx_rows_4_f32_f64_fma, "AVX2 FMA");
+    }
+
+    fn run_rows_4_comparison(
+        simd_fn: fn(&[f32], usize, &mut [f32], usize, &FilterWeights<f64>, u32),
+        label: &str,
+    ) {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_simd = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_4_row_f32_f64::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, src_stride, &mut dst_simd, dst_stride, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgb_u16.rs
+++ b/src/avx2/rgb_u16.rs
@@ -594,3 +594,130 @@ impl<const FMA: bool> OneRowExecutionHandlerRgb<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_horizontal::{
+        convolve_row_handler_floating_point, convolve_row_handler_floating_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    const BIT_DEPTH: u32 = 16;
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, only reproducible when compiled without FMA (e.g. CI's isolated no-FMA jobs) - see issue"]
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 3, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * 3];
+                let mut dst_avx2 = vec![0u16; out_size * 3];
+                convolve_row_handler_floating_point::<u16, f32, f32, 3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_avx_u16_row_default(
+                    &src,
+                    &mut dst_avx2,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 RGB u16 single-row (default) output diverges from the scalar reference"
+                );
+
+                if std::arch::is_x86_feature_detected!("fma") {
+                    let mut dst_avx2_fma = vec![0u16; out_size * 3];
+                    convolve_horizontal_rgb_avx_u16_row_fma(
+                        &src,
+                        &mut dst_avx2_fma,
+                        &filter_weights,
+                        BIT_DEPTH,
+                    );
+
+                    assert_eq!(
+                        dst_scalar, dst_avx2_fma,
+                        "{resampling:?} {in_size}->{out_size}: AVX2 RGB u16 single-row (fma) output diverges from the scalar reference"
+                    );
+                }
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, 3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_avx_rows_4_u16_default(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 RGB u16 4-row (default) output diverges from the scalar reference"
+                );
+
+                if std::arch::is_x86_feature_detected!("fma") {
+                    let mut dst_avx2_fma = vec![0u16; dst_stride * ROWS];
+                    convolve_horizontal_rgb_avx_rows_4_u16_fma(
+                        &src,
+                        src_stride,
+                        &mut dst_avx2_fma,
+                        dst_stride,
+                        &filter_weights,
+                        BIT_DEPTH,
+                    );
+
+                    assert_eq!(
+                        dst_scalar, dst_avx2_fma,
+                        "{resampling:?} {in_size}->{out_size}: AVX2 RGB u16 4-row (fma) output diverges from the scalar reference"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/avx2/rgb_u16_lb.rs
+++ b/src/avx2/rgb_u16_lb.rs
@@ -622,3 +622,91 @@ impl<const D: bool> OneRowExecutionUnitRgb<D> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 3, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; out_size * 3];
+                let mut dst_avx2 = vec![0u16; out_size * 3];
+                convolve_row_handler_fixed_point::<u16, i32, 3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_avx_u16lp_row(&src, &mut dst_avx2, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 RGB u16 lb single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<u16, i32, 3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_avx_rows_4_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 RGB u16 lb 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgb_u8.rs
+++ b/src/avx2/rgb_u8.rs
@@ -647,3 +647,82 @@ impl<const HAS_DOT: bool> Row1Execution<HAS_DOT> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 3);
+
+                let mut dst_scalar = vec![0u8; out_size * 3];
+                let mut dst_avx2 = vec![0u8; out_size * 3];
+                handle_fixed_row_u8::<3>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgb_avx_row_one(&src, &mut dst_avx2, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 RGB single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_avx_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 RGB 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgba_f16.rs
+++ b/src/avx2/rgba_f16.rs
@@ -515,3 +515,125 @@ fn convolve_horizontal_rgba_avx_rows_4_f16_impl<const FMA: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // AVX2 packs multiple taps per 256-bit register and reduces the two
+    // 128-bit halves at the end, and the FMA variant fuses multiply+add -
+    // both reorder and re-round relative to the scalar loop's strictly
+    // sequential multiply-then-add, so a small tolerance is expected here.
+    const ATOL: f32 = 1e-3;
+
+    fn required_features(fma: bool) -> bool {
+        let base = is_x86_feature_detected!("avx2") && is_x86_feature_detected!("f16c");
+        if fma { base && is_x86_feature_detected!("fma") } else { base }
+    }
+
+    #[test]
+    fn avx2_default_row_matches_scalar_reference() {
+        if !required_features(false) {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgba_avx_row_one_f16::<false>, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_row_matches_scalar_reference() {
+        if !required_features(true) {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgba_avx_row_one_f16::<true>, "AVX2 FMA");
+    }
+
+    fn run_row_comparison(
+        simd_fn: fn(&[f16], &mut [f16], &FilterWeights<f32>, u32),
+        label: &str,
+    ) {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f16; out_size * 4];
+                let mut dst_simd = vec![0f16; out_size * 4];
+                convolve_horizontal_rgb_native_row_f16::<4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, &mut dst_simd, &filter_weights, 8);
+
+                assert_f16_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_default_rows_4_matches_scalar_reference() {
+        if !required_features(false) {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgba_avx_rows_4_f16::<false>, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_rows_4_matches_scalar_reference() {
+        if !required_features(true) {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgba_avx_rows_4_f16::<true>, "AVX2 FMA");
+    }
+
+    fn run_rows_4_comparison(
+        simd_fn: fn(&[f16], usize, &mut [f16], usize, &FilterWeights<f32>, u32),
+        label: &str,
+    ) {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_simd = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, src_stride, &mut dst_simd, dst_stride, &filter_weights, 8);
+
+                assert_f16_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgba_f32.rs
+++ b/src/avx2/rgba_f32.rs
@@ -582,3 +582,115 @@ impl<const FMA: bool> OneRowExecutionUnit<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32};
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // AVX2 packs two taps per 256-bit register and reduces the two 128-bit
+    // halves at the end, and the FMA variant fuses multiply+add - both reorder
+    // and re-round relative to the scalar loop's strictly sequential
+    // multiply-then-add, so a small tolerance (not bit-exact) is expected here.
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn avx2_default_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgba_avx_row_one_f32_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_row_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgba_avx_row_one_f32_fma, "AVX2 FMA");
+    }
+
+    fn run_row_comparison(
+        simd_fn: fn(&[f32], &mut [f32], &FilterWeights<f32>, u32),
+        label: &str,
+    ) {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f32; out_size * 4];
+                let mut dst_simd = vec![0f32; out_size * 4];
+                convolve_horizontal_native_row_f32::<4>(&src, &mut dst_scalar, &filter_weights, 8);
+                simd_fn(&src, &mut dst_simd, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_default_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgba_avx_rows_4_f32_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_rows_4_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgba_avx_rows_4_f32_fma, "AVX2 FMA");
+    }
+
+    fn run_rows_4_comparison(
+        simd_fn: fn(&[f32], usize, &mut [f32], usize, &FilterWeights<f32>, u32),
+        label: &str,
+    ) {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_simd = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, src_stride, &mut dst_simd, dst_stride, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgba_f32_f64.rs
+++ b/src/avx2/rgba_f32_f64.rs
@@ -364,3 +364,130 @@ impl<const FMA: bool> OneRowExecutionUnit<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_4_row_f32_f64, convolve_horizontal_native_row_f32_f64,
+    };
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    /// See the identical helper in `src/avx2/plane_f32_f64.rs` - `PreferQuality`
+    /// weights are `f64`, which `test_utils` doesn't build a helper for.
+    fn make_row_filter_weights_f64(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<f64>, PicScaleError> {
+        <f32 as WeightsGenerator<f64>>::make_weights(resampling, in_size, out_size)
+    }
+
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn avx2_default_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgba_avx_row_one_f32_f64_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_row_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_row_comparison(convolve_horizontal_rgba_avx_row_one_f32_f64_fma, "AVX2 FMA");
+    }
+
+    fn run_row_comparison(
+        simd_fn: fn(&[f32], &mut [f32], &FilterWeights<f64>, u32),
+        label: &str,
+    ) {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f32; out_size * 4];
+                let mut dst_simd = vec![0f32; out_size * 4];
+                convolve_horizontal_native_row_f32_f64::<4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, &mut dst_simd, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_default_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgba_avx_rows_4_f32_f64_default, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_rows_4_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_rows_4_comparison(convolve_horizontal_rgba_avx_rows_4_f32_f64_fma, "AVX2 FMA");
+    }
+
+    fn run_rows_4_comparison(
+        simd_fn: fn(&[f32], usize, &mut [f32], usize, &FilterWeights<f64>, u32),
+        label: &str,
+    ) {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_simd = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_4_row_f32_f64::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                simd_fn(&src, src_stride, &mut dst_simd, dst_stride, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_simd,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: {label} 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgba_u16.rs
+++ b/src/avx2/rgba_u16.rs
@@ -640,3 +640,176 @@ impl<const FMA: bool> OneRowExecutionHandler<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_horizontal::{
+        convolve_row_handler_floating_point, convolve_row_handler_floating_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    const BIT_DEPTH: u32 = 16;
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, only reproducible when compiled without FMA (e.g. CI's isolated no-FMA jobs) - see issue"]
+    #[test]
+    fn avx2_default_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 4, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * 4];
+                let mut dst_avx2 = vec![0u16; out_size * 4];
+                convolve_row_handler_floating_point::<u16, f32, f32, 4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_avx_u16_row_default(
+                    &src,
+                    &mut dst_avx2,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 default single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn avx2_fma_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 4, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * 4];
+                let mut dst_avx2 = vec![0u16; out_size * 4];
+                convolve_row_handler_floating_point::<u16, f32, f32, 4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_avx_u16_row_fma(&src, &mut dst_avx2, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 fma single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, only reproducible when compiled without FMA (e.g. CI's isolated no-FMA jobs) - see issue"]
+    #[test]
+    fn avx2_default_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, 4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_avx_rows_4_u16_default(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 default 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn avx2_fma_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, 4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_avx_rows_4_u16_fma(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 fma 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/rgba_u16_lb.rs
+++ b/src/avx2/rgba_u16_lb.rs
@@ -595,3 +595,180 @@ impl<const D: bool> OneRowExecutionUnit<D> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 4, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; out_size * 4];
+                let mut dst_avx2 = vec![0u16; out_size * 4];
+                convolve_row_handler_fixed_point::<u16, i32, 4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_avx_u16lp_row(&src, &mut dst_avx2, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 lb single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<u16, i32, 4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_avx_rows_4_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 lb 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_vnni_row_matches_scalar_reference() {
+        #[cfg(feature = "avx512")]
+        {
+            if !std::arch::is_x86_feature_detected!("avxvnni") {
+                return;
+            }
+            for resampling in [
+                ResamplingFunction::Bilinear,
+                ResamplingFunction::Lanczos3,
+                ResamplingFunction::Nearest,
+            ] {
+                for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                    let filter_weights =
+                        make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                    let mut rng =
+                        XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                    let src = rng.fill_u16(in_size * 4, (1u16 << BIT_DEPTH) - 1);
+
+                    let mut dst_scalar = vec![0u16; out_size * 4];
+                    let mut dst_avx2 = vec![0u16; out_size * 4];
+                    convolve_row_handler_fixed_point::<u16, i32, 4>(
+                        &src,
+                        &mut dst_scalar,
+                        &filter_weights,
+                        BIT_DEPTH,
+                    );
+                    convolve_horizontal_rgba_avx_u16lp_row_vnni(
+                        &src,
+                        &mut dst_avx2,
+                        &filter_weights,
+                        BIT_DEPTH,
+                    );
+
+                    assert_eq!(
+                        dst_scalar, dst_avx2,
+                        "{resampling:?} {in_size}->{out_size}: AVX2 VNNI single-row output diverges from the scalar reference"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_vnni_rows_4_matches_scalar_reference() {
+        #[cfg(feature = "avx512")]
+        {
+            if !std::arch::is_x86_feature_detected!("avxvnni") {
+                return;
+            }
+            const ROWS: usize = 4;
+            for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+                for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                    let filter_weights =
+                        make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                    let mut rng =
+                        XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                    let src_stride = in_size * 4;
+                    let dst_stride = out_size * 4;
+                    let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                    let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                    let mut dst_avx2 = vec![0u16; dst_stride * ROWS];
+                    convolve_row_handler_fixed_point_4::<u16, i32, 4>(
+                        &src,
+                        src_stride,
+                        &mut dst_scalar,
+                        dst_stride,
+                        &filter_weights,
+                        BIT_DEPTH,
+                    );
+                    convolve_horizontal_rgba_avx_rows_4_u16_vnni(
+                        &src,
+                        src_stride,
+                        &mut dst_avx2,
+                        dst_stride,
+                        &filter_weights,
+                        BIT_DEPTH,
+                    );
+
+                    assert_eq!(
+                        dst_scalar, dst_avx2,
+                        "{resampling:?} {in_size}->{out_size}: AVX2 VNNI 4-row output diverges from the scalar reference"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/avx2/rgba_u8.rs
+++ b/src/avx2/rgba_u8.rs
@@ -494,3 +494,82 @@ fn convolve_horizontal_rgba_avx_rows_one_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn avx2_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 4);
+
+                let mut dst_scalar = vec![0u8; out_size * 4];
+                let mut dst_avx2 = vec![0u8; out_size * 4];
+                handle_fixed_row_u8::<4>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgba_avx_row_1(&src, &mut dst_avx2, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_avx2 = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_row_4(
+                    &src,
+                    src_stride,
+                    &mut dst_avx2,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_avx2,
+                    "{resampling:?} {in_size}->{out_size}: AVX2 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/avx2/vertical_ar30.rs
+++ b/src/avx2/vertical_ar30.rs
@@ -213,3 +213,140 @@ impl<const AR30_TYPE: usize, const AR30_ORDER: usize> ExecutionUnit<AR30_TYPE, A
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::factory::{Ar30ByteOrder, Rgb30};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    /// Vertical counterpart of the scalar reference in `horizontal_ar30.rs`:
+    /// same Q15 fixed-point math (`support::PRECISION`), but each output
+    /// pixel accumulates taps from `bounds.size` different SOURCE ROWS
+    /// (via `src_stride`) instead of `bounds.size` taps within one row.
+    fn scalar_reference_ar30_column<const AR_TYPE: usize, const AR_ORDER: usize>(
+        width: usize,
+        bounds: &FilterBounds,
+        src: &[u8],
+        dst: &mut [u8],
+        src_stride: usize,
+        weight: &[i16],
+    ) {
+        const PRECISION: i32 = 15;
+        const ROUNDING: i32 = 1 << (PRECISION - 1);
+        let rgb_type: Rgb30 = AR_TYPE.into();
+
+        for x in 0..width {
+            let mut acc_r = ROUNDING;
+            let mut acc_g = ROUNDING;
+            let mut acc_b = ROUNDING;
+            for (j, &w) in weight.iter().enumerate().take(bounds.size) {
+                let py = bounds.start + j;
+                let offset = src_stride * py + x * 4;
+                let word = u32::from_ne_bytes(src[offset..offset + 4].try_into().unwrap());
+                let (r, g, b, _a) = rgb_type.unpack::<AR_ORDER>(word);
+                acc_r += r as i32 * w as i32;
+                acc_g += g as i32 * w as i32;
+                acc_b += b as i32 * w as i32;
+            }
+            let r = (acc_r >> PRECISION).clamp(0, 1023);
+            let g = (acc_g >> PRECISION).clamp(0, 1023);
+            let b = (acc_b >> PRECISION).clamp(0, 1023);
+            let packed = rgb_type.pack_w_a::<AR_ORDER>(r, g, b, 3);
+            let dst_offset = x * 4;
+            dst[dst_offset..dst_offset + 4].copy_from_slice(&packed.to_ne_bytes());
+        }
+    }
+
+    fn make_ar30_src<const AR_ORDER: usize>(
+        rgb_type: Rgb30,
+        rng: &mut XorShiftRng,
+        pixel_count: usize,
+    ) -> Vec<u8> {
+        let components = rng.fill_u16(pixel_count * 3, 1023);
+        let mut out = Vec::with_capacity(pixel_count * 4);
+        for chunk in components.as_chunks::<3>().0 {
+            let packed =
+                rgb_type.pack_w_a::<AR_ORDER>(chunk[0] as i32, chunk[1] as i32, chunk[2] as i32, 3);
+            out.extend_from_slice(&packed.to_ne_bytes());
+        }
+        out
+    }
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    fn run_vertical_test<const AR_TYPE: usize, const AR_ORDER: usize>(label: &str) {
+        let rgb_type: Rgb30 = AR_TYPE.into();
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src_stride = width * 4;
+                    let src = make_ar30_src::<AR_ORDER>(rgb_type, &mut rng, width * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u8; width * 4];
+                        let mut dst_avx = vec![0u8; width * 4];
+                        scalar_reference_ar30_column::<AR_TYPE, AR_ORDER>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                        );
+                        avx_column_handler_fixed_point_ar30::<AR_TYPE, AR_ORDER>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_avx,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_avx,
+                            "{label} {resampling:?} {in_height}->{out_height} row {y} width {width}: AVX2 AR30 vertical output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_vertical_test::<{ Rgb30::Ar30 as usize }, { Ar30ByteOrder::Host as usize }>(
+            "AR30 host",
+        );
+        run_vertical_test::<{ Rgb30::Ar30 as usize }, { Ar30ByteOrder::Network as usize }>(
+            "AR30 network",
+        );
+        run_vertical_test::<{ Rgb30::Ra30 as usize }, { Ar30ByteOrder::Host as usize }>(
+            "RA30 host",
+        );
+        run_vertical_test::<{ Rgb30::Ra30 as usize }, { Ar30ByteOrder::Network as usize }>(
+            "RA30 network",
+        );
+    }
+}

--- a/src/avx2/vertical_f16.rs
+++ b/src/avx2/vertical_f16.rs
@@ -319,3 +319,103 @@ fn convolve_vertical_avx_row_f16_impl<const FMA: bool>(
         cx += 1;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::convolve_vertical_rgb_native_row_f16;
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // The scalar reference widens `f16` to `f32`, convolves, then narrows
+    // back; the AVX2 backend does the same via `f16c` `vcvtph2ps`/`vcvtps2ph`
+    // but accumulates in 8/16/32-wide chunks (and fuses multiply+add for the
+    // FMA variant), reordering relative to the scalar loop's strictly
+    // sequential multiply-then-add. `1e-5` (the `f32`-accumulator tolerance)
+    // is too tight once the result is narrowed to `f16`: a single ULP at the
+    // `f16` mantissa's precision near typical test values (~0.4) is already
+    // ~2.4e-4, so match the `1e-3` tolerance used by the existing f16
+    // horizontal comparison tests (e.g. `avx2/rgba_f16.rs`).
+    const ATOL: f32 = 1e-3;
+
+    #[test]
+    fn avx2_f16_default_vertical_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("f16c")) {
+            return;
+        }
+        run_vertical_comparison(convolve_vertical_avx_row_f16::<false>, "AVX2 f16 default");
+    }
+
+    #[test]
+    fn avx2_f16_fma_vertical_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2")
+            && is_x86_feature_detected!("f16c")
+            && is_x86_feature_detected!("fma"))
+        {
+            return;
+        }
+        run_vertical_comparison(convolve_vertical_avx_row_f16::<true>, "AVX2 f16 FMA");
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_vertical_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[f16], &mut [f16], usize, &[f32], u32),
+        label: &str,
+    ) {
+        // Row widths chosen to be multiples of 1 (plane), 3 (rgb) and 4 (rgba)
+        // pixels, plus a couple of odd sizes so every SIMD tail-loop width
+        // (32/16/4/1 lanes) gets exercised at least once.
+        const ROW_WIDTHS: [usize; 7] = [1, 3, 4, 39, 99, 160, 41];
+
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+
+                for &row_width in ROW_WIDTHS.iter() {
+                    let src_stride = row_width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE
+                            ^ (in_height as u64) << 32
+                            ^ (out_height as u64) << 16
+                            ^ row_width as u64,
+                    );
+                    let src = rng.fill_f16_unit(src_stride * in_height);
+
+                    for y in 0..out_height {
+                        let bounds = filter_weights.bounds[y];
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f16; row_width];
+                        let mut dst_simd = vec![0f16; row_width];
+
+                        convolve_vertical_rgb_native_row_f16(
+                            0,
+                            &bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        simd_fn(row_width, &bounds, &src, &mut dst_simd, src_stride, weights, 8);
+
+                        assert_f16_slices_close(
+                            &dst_simd,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {row_width}: {label}"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/avx2/vertical_f32.rs
+++ b/src/avx2/vertical_f32.rs
@@ -405,3 +405,95 @@ impl<const FMA: bool> ExecutionUnit<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_vertical::column_handler_floating_point;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // AVX2 folds 8/16/32 lanes at a time and the FMA variant fuses multiply+add,
+    // both of which reorder and re-round relative to the scalar loop's strictly
+    // sequential multiply-then-add - a small tolerance (not bit-exact) is
+    // expected here, mirroring the horizontal-convolution comparison tests.
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn avx2_default_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_vertical_comparison(convolve_vertical_avx_row_default_f32, "AVX2 default");
+    }
+
+    #[test]
+    fn avx2_fma_vertical_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_vertical_comparison(convolve_vertical_avx_row_fma_f32, "AVX2 FMA");
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_vertical_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[f32], &mut [f32], usize, &[f32], u32),
+        label: &str,
+    ) {
+        // Row widths chosen to be multiples of 1 (plane), 3 (rgb) and 4 (rgba)
+        // pixels, plus a couple of odd sizes so every SIMD tail-loop width
+        // (32/16/8/1 lanes) gets exercised at least once.
+        const ROW_WIDTHS: [usize; 7] = [1, 3, 4, 39, 99, 160, 41];
+
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+
+                for &row_width in ROW_WIDTHS.iter() {
+                    let src_stride = row_width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE
+                            ^ (in_height as u64) << 32
+                            ^ (out_height as u64) << 16
+                            ^ row_width as u64,
+                    );
+                    let src = rng.fill_f32_unit(src_stride * in_height);
+
+                    for y in 0..out_height {
+                        let bounds = filter_weights.bounds[y];
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f32; row_width];
+                        let mut dst_simd = vec![0f32; row_width];
+
+                        column_handler_floating_point::<f32, f32, f32>(
+                            0,
+                            &bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        simd_fn(row_width, &bounds, &src, &mut dst_simd, src_stride, weights, 8);
+
+                        assert_f32_slices_close(
+                            &dst_simd,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {row_width}: {label}"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/avx2/vertical_f32_f64.rs
+++ b/src/avx2/vertical_f32_f64.rs
@@ -332,3 +332,99 @@ impl<const FMA: bool> ExecutionUnit<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_vertical::column_handler_floating_point;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    // This is the `PreferQuality` path: weights and the accumulator are both
+    // `f64`, only narrowed back to `f32` on store. AVX2 still folds several
+    // lanes per register and (for the FMA variant) fuses multiply+add, which
+    // reorders relative to the scalar loop's strictly sequential
+    // multiply-then-add - a small tolerance is expected, same reasoning as
+    // the `f32`-weighted vertical comparison in `vertical_f32.rs`.
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn avx2_f64_default_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_vertical_comparison(convolve_vertical_avx_row_f32_f64_default, "AVX2 f64 default");
+    }
+
+    #[test]
+    fn avx2_f64_fma_vertical_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_vertical_comparison(convolve_vertical_avx_row_f32_f64_fma, "AVX2 f64 FMA");
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_vertical_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[f32], &mut [f32], usize, &[f64], u32),
+        label: &str,
+    ) {
+        // Row widths chosen to be multiples of 1 (plane), 3 (rgb) and 4 (rgba)
+        // pixels, plus a couple of odd sizes so every SIMD tail-loop width
+        // (16/8/1 lanes) gets exercised at least once.
+        const ROW_WIDTHS: [usize; 7] = [1, 3, 4, 39, 99, 160, 41];
+
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    <f32 as WeightsGenerator<f64>>::make_weights(resampling, in_height, out_height)
+                        .unwrap();
+
+                for &row_width in ROW_WIDTHS.iter() {
+                    let src_stride = row_width;
+                    let mut rng = XorShiftRng::new(
+                        0xBADF00D
+                            ^ (in_height as u64) << 32
+                            ^ (out_height as u64) << 16
+                            ^ row_width as u64,
+                    );
+                    let src = rng.fill_f32_unit(src_stride * in_height);
+
+                    for y in 0..out_height {
+                        let bounds = filter_weights.bounds[y];
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f32; row_width];
+                        let mut dst_simd = vec![0f32; row_width];
+
+                        column_handler_floating_point::<f32, f64, f64>(
+                            0,
+                            &bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        simd_fn(row_width, &bounds, &src, &mut dst_simd, src_stride, weights, 8);
+
+                        assert_f32_slices_close(
+                            &dst_simd,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {row_width}: {label}"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/avx2/vertical_s16_lb.rs
+++ b/src/avx2/vertical_s16_lb.rs
@@ -483,3 +483,81 @@ fn convolve_column_lb_avx_i16_impl<const HAS_DOT: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_vertical::column_handler_fixed_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    // Signed-`i16` counterpart of `src/avx2/vertical_u16_lb.rs`: the
+    // accelerated low-bit-depth (<=12 bit) fixed-point path must agree
+    // bit-for-bit with `column_handler_fixed_point::<i16, i32>`, the scalar
+    // reference `ImageStore<i16, 1>::vertical_plan` falls back to.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    fn fill_i16(rng: &mut XorShiftRng, len: usize) -> Vec<i16> {
+        rng.fill_u16(len, u16::MAX).into_iter().map(|v| v as i16).collect()
+    }
+
+    #[test]
+    fn avx2_vertical_lb_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        const BIT_DEPTH: u32 = 12;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = fill_i16(&mut rng, src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0i16; width];
+                        let mut dst_avx = vec![0i16; width];
+                        column_handler_fixed_point::<i16, i32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_column_lb_avx2_s16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_avx,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_avx,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: AVX2 vertical lb (s16) output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/avx2/vertical_u16.rs
+++ b/src/avx2/vertical_u16.rs
@@ -587,3 +587,88 @@ fn convolve_column_lb_u16_impl<const FMA: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_vertical::column_handler_floating_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    // Same high-bit-depth (>12 bit) rationale as sse/vertical_u16.rs: both
+    // this SIMD function and its scalar reference
+    // (`column_handler_floating_point::<u16, f32, f32>`) accumulate in `f32`
+    // with real (non-quantized) weights.
+    const BIT_DEPTH: u32 = 16;
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    fn run_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[u16], &mut [u16], usize, &[f32], u32),
+        label: &str,
+    ) {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng
+                        .fill_u16(src_stride * needed_rows, ((1u32 << BIT_DEPTH) - 1) as u16);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u16; width];
+                        let mut dst_simd = vec![0u16; width];
+                        column_handler_floating_point::<u16, f32, f32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        simd_fn(width, bounds, &src, &mut dst_simd, src_stride, weights, BIT_DEPTH);
+
+                        assert_eq!(
+                            dst_scalar, dst_simd,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: {label} vertical (16-bit) output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn avx2_default_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_comparison(convolve_column_avx_u16_default, "AVX2 default");
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn avx2_fma_vertical_matches_scalar_reference() {
+        if !(is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")) {
+            return;
+        }
+        run_comparison(convolve_column_avx_u16_fma, "AVX2 FMA");
+    }
+}

--- a/src/avx2/vertical_u16_lb.rs
+++ b/src/avx2/vertical_u16_lb.rs
@@ -495,3 +495,85 @@ fn convolve_column_lb_avx_u16_impl<const HAS_DOT: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_vertical::column_handler_fixed_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    // Same idea as the u8 vertical tests in `src/avx2/vertical_u8.rs`: for
+    // every output row the accelerated low-bit-depth (<=12 bit) fixed-point
+    // path must agree bit-for-bit with `column_handler_fixed_point::<u16, i32>`,
+    // the same scalar reference `default_u16_column_plan` falls back to.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    fn run_case(
+        run: impl Fn(usize, &FilterBounds, &[u16], &mut [u16], usize, &[i16], u32),
+        context: &str,
+    ) {
+        const BIT_DEPTH: u32 = 12;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u16(src_stride * needed_rows, (1u16 << BIT_DEPTH) - 1);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u16; width];
+                        let mut dst_avx = vec![0u16; width];
+                        column_handler_fixed_point::<u16, i32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        run(width, bounds, &src, &mut dst_avx, src_stride, weights, BIT_DEPTH);
+
+                        assert_eq!(
+                            dst_scalar, dst_avx,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: {context} vertical lb output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_vertical_lb_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        run_case(convolve_column_lb_avx2_u16, "AVX2");
+    }
+
+    #[cfg(feature = "avx512")]
+    #[test]
+    fn avx2_vertical_lb_vnni_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("avxvnni") {
+            return;
+        }
+        run_case(convolve_column_lb_avx2_u16_vnni, "AVX2 VNNI");
+    }
+}

--- a/src/avx2/vertical_u8.rs
+++ b/src/avx2/vertical_u8.rs
@@ -456,3 +456,77 @@ impl<const HAS_DOT: bool> ExecutionUnit<HAS_DOT> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::handle_fixed_column_u8;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    // Same idea as the horizontal backend-comparison tests (see
+    // `src/avx2/rgba_u8.rs`), but for the vertical (column) pass. Note that
+    // `convolve_vertical_avx_row` internally runtime-dispatches to an AVX-VNNI
+    // dot-product path when available, so this single test transparently
+    // exercises whichever path the host CPU supports.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn avx2_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[13usize, 131usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u8(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u8; width];
+                        let mut dst_avx = vec![0u8; width];
+                        handle_fixed_column_u8(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        convolve_vertical_avx_row(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_avx,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_avx,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: AVX2 vertical output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/avx512/rgba_u8_dot_vnni.rs
+++ b/src/avx512/rgba_u8_dot_vnni.rs
@@ -512,3 +512,82 @@ fn convolve_horizontal_rgba_vnni_rows_one_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn avx512_vnni_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avxvnni") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 4);
+
+                let mut dst_scalar = vec![0u8; out_size * 4];
+                let mut dst_vnni = vec![0u8; out_size * 4];
+                handle_fixed_row_u8::<4>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgba_vnni_row_1(&src, &mut dst_vnni, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_vnni,
+                    "{resampling:?} {in_size}->{out_size}: AVX-512 VNNI single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn avx512_vnni_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("avxvnni") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_vnni = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_vnni_row_4(
+                    &src,
+                    src_stride,
+                    &mut dst_vnni,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_vnni,
+                    "{resampling:?} {in_size}->{out_size}: AVX-512 VNNI 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -67,7 +67,7 @@ use crate::{ImageStore, ThreadingPolicy};
 use core::{f16, f32};
 use std::sync::Arc;
 
-fn convolve_horizontal_rgba_4_row_f16<const CN: usize>(
+pub(crate) fn convolve_horizontal_rgba_4_row_f16<const CN: usize>(
     src: &[f16],
     src_stride: usize,
     dst: &mut [f16],
@@ -90,7 +90,7 @@ fn convolve_horizontal_rgba_4_row_f16<const CN: usize>(
     }
 }
 
-fn convolve_horizontal_rgb_native_row_f16<const CN: usize>(
+pub(crate) fn convolve_horizontal_rgb_native_row_f16<const CN: usize>(
     src: &[f16],
     dst: &mut [f16],
     filter_weights: &FilterWeights<f32>,
@@ -183,7 +183,7 @@ impl HorizontalFilterPass<f16, f32, 4> for ImageStore<'_, f16, 4> {
     }
 }
 
-fn convolve_vertical_rgb_native_row_f16(
+pub(crate) fn convolve_vertical_rgb_native_row_f16(
     _: usize,
     bounds: &FilterBounds,
     src: &[f16],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,8 @@ mod sse;
 mod support;
 #[cfg(all(target_arch = "aarch64", feature = "sve"))]
 mod sve2;
+#[cfg(test)]
+mod test_utils;
 mod threading_policy;
 mod validation;
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]

--- a/src/neon/alpha_f16.rs
+++ b/src/neon/alpha_f16.rs
@@ -188,3 +188,74 @@ pub(crate) fn neon_unpremultiply_alpha_rgba_f16(in_place: &mut [f16]) {
         neon_unpremultiply_alpha_rgba_row_f16(in_place);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close};
+
+    // f16 has only ~10 bits of mantissa, so the f32-domain rounding
+    // differences between the scalar reference and the NEON (f16<->f32
+    // conversion + multiply/divide) path can move the result by roughly one
+    // f16 ULP. Random alpha is kept away from 0 (see `make_rgba`) so
+    // unpremultiply's relative error stays small in absolute terms too.
+    const ATOL: f32 = 1e-3;
+
+    /// Builds an RGBA f16 buffer in `[0, 1)` that mixes alpha == 0, alpha == 1
+    /// and fully random pixels (with random alpha kept away from 0) so both
+    /// the vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<f16> {
+        let mut buf = rng.fill_f16_unit(pixels * 4);
+        for chunk in buf.as_chunks_mut::<4>().0 {
+            chunk[3] = (0.05 + 0.95 * chunk[3] as f32) as f16;
+        }
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0.;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 1.;
+        }
+        buf
+    }
+
+    #[test]
+    fn neon_premultiply_matches_scalar_reference() {
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0f16; pixels * 4];
+            let mut dst_neon = vec![0f16; pixels * 4];
+            premultiply_pixel_f16_row(&mut dst_scalar, &src);
+            neon_premultiply_alpha_rgba_f16(&mut dst_neon, &src);
+
+            assert_f16_slices_close(
+                &dst_neon,
+                &dst_scalar,
+                ATOL,
+                &format!("{pixels} pixels: NEON premultiply"),
+            );
+        }
+    }
+
+    #[test]
+    fn neon_unpremultiply_matches_scalar_reference() {
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut neon_buf = src;
+            unpremultiply_pixel_f16_row(&mut scalar_buf);
+            neon_unpremultiply_alpha_rgba_f16(&mut neon_buf);
+
+            assert_f16_slices_close(
+                &neon_buf,
+                &scalar_buf,
+                ATOL,
+                &format!("{pixels} pixels: NEON unpremultiply"),
+            );
+        }
+    }
+}

--- a/src/neon/alpha_f16_full.rs
+++ b/src/neon/alpha_f16_full.rs
@@ -194,3 +194,83 @@ pub(crate) fn neon_unpremultiply_alpha_rgba_f16_full(in_place: &mut [f16]) {
         neon_unpremultiply_alpha_rgba_f16_row_full(in_place);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::alpha_handle_f16::unpremultiply_pixel_f16_row;
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close};
+
+    // This backend computes premultiply/unpremultiply directly in f16
+    // (`fp16` NEON arithmetic), while the scalar reference widens to f32
+    // first. That extra intermediate rounding step means the two can
+    // legitimately differ by roughly one f16 ULP. Random alpha is kept away
+    // from 0 (see `make_rgba`) so unpremultiply's relative error stays small
+    // in absolute terms too.
+    const ATOL: f32 = 1e-3;
+
+    /// Builds an RGBA f16 buffer in `[0, 1)` that mixes alpha == 0, alpha == 1
+    /// and fully random pixels (with random alpha kept away from 0) so both
+    /// the vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<f16> {
+        let mut buf = rng.fill_f16_unit(pixels * 4);
+        for chunk in buf.as_chunks_mut::<4>().0 {
+            chunk[3] = (0.05 + 0.95 * chunk[3] as f32) as f16;
+        }
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0.;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 1.;
+        }
+        buf
+    }
+
+    #[test]
+    fn neon_fp16_premultiply_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0f16; pixels * 4];
+            let mut dst_neon = vec![0f16; pixels * 4];
+            premultiply_pixel_f16_row(&mut dst_scalar, &src);
+            neon_premultiply_alpha_rgba_f16_full(&mut dst_neon, &src);
+
+            assert_f16_slices_close(
+                &dst_neon,
+                &dst_scalar,
+                ATOL,
+                &format!("{pixels} pixels: NEON fp16 premultiply"),
+            );
+        }
+    }
+
+    #[ignore = "known bug: same alpha==0 handling / precision divergence class as the u16 unpremultiply findings - see issue"]
+    #[test]
+    fn neon_fp16_unpremultiply_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut neon_buf = src;
+            unpremultiply_pixel_f16_row(&mut scalar_buf);
+            neon_unpremultiply_alpha_rgba_f16_full(&mut neon_buf);
+
+            assert_f16_slices_close(
+                &neon_buf,
+                &scalar_buf,
+                ATOL,
+                &format!("{pixels} pixels: NEON fp16 unpremultiply"),
+            );
+        }
+    }
+}

--- a/src/neon/alpha_f32.rs
+++ b/src/neon/alpha_f32.rs
@@ -159,3 +159,77 @@ fn neon_unpremultiply_alpha_rgba_f32_row(in_place: &mut [f32]) {
 pub(crate) fn neon_unpremultiply_alpha_rgba_f32(in_place: &mut [f32]) {
     unsafe { neon_unpremultiply_alpha_rgba_f32_row(in_place) }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::alpha_handle_f32::{premultiply_rgba_f32_row, unpremultiply_rgba_f32_row};
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    // Premultiply is a plain per-lane multiply with no reassociation, so it
+    // is bit-exact against the scalar reference. Unpremultiply is not: the
+    // scalar reference computes `1. / a` and then multiplies, while NEON
+    // does a direct division - mathematically the same but rounded
+    // differently, so it can be off by a few ULPs. Random alpha is kept
+    // away from 0 (see `make_rgba`) so that relative error stays small in
+    // absolute terms too.
+    const ATOL: f32 = 1e-4;
+
+    /// Builds an RGBA f32 buffer in `[0, 1)` that mixes alpha == 0, alpha == 1
+    /// and fully random pixels (with random alpha kept away from 0) so both
+    /// the vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<f32> {
+        let mut buf = rng.fill_f32_unit(pixels * 4);
+        for chunk in buf.as_chunks_mut::<4>().0 {
+            chunk[3] = 0.05 + 0.95 * chunk[3];
+        }
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0.;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 1.;
+        }
+        buf
+    }
+
+    #[test]
+    fn neon_premultiply_matches_scalar_reference() {
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0f32; pixels * 4];
+            let mut dst_neon = vec![0f32; pixels * 4];
+            premultiply_rgba_f32_row(&mut dst_scalar, &src);
+            neon_premultiply_alpha_rgba_f32(&mut dst_neon, &src);
+
+            assert_f32_slices_close(
+                &dst_neon,
+                &dst_scalar,
+                ATOL,
+                &format!("{pixels} pixels: NEON premultiply"),
+            );
+        }
+    }
+
+    #[test]
+    fn neon_unpremultiply_matches_scalar_reference() {
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut neon_buf = src;
+            unpremultiply_rgba_f32_row(&mut scalar_buf);
+            neon_unpremultiply_alpha_rgba_f32(&mut neon_buf);
+
+            assert_f32_slices_close(
+                &neon_buf,
+                &scalar_buf,
+                ATOL,
+                &format!("{pixels} pixels: NEON unpremultiply"),
+            );
+        }
+    }
+}

--- a/src/neon/alpha_u16.rs
+++ b/src/neon/alpha_u16.rs
@@ -470,3 +470,67 @@ fn neon_unpremultiply_alpha_rgba_row_u16(in_place: &mut [u16], bit_depth: usize)
 pub(crate) fn neon_unpremultiply_alpha_rgba_u16(in_place: &mut [u16], bit_depth: usize) {
     neon_unpremultiply_alpha_rgba_row_u16(in_place, bit_depth);
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::alpha_handle_u16::{premultiply_alpha_rgba_row, unpremultiply_alpha_rgba_row};
+    use crate::test_utils::XorShiftRng;
+
+    /// Builds an RGBA16 buffer (values clamped to `bit_depth`) that mixes
+    /// alpha == 0, alpha == max and fully random pixels, so both the
+    /// vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize, bit_depth: usize) -> Vec<u16> {
+        let max_colors = ((1u32 << bit_depth) - 1) as u16;
+        let mut buf = rng.fill_u16(pixels * 4, max_colors);
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = max_colors;
+        }
+        buf
+    }
+
+    #[test]
+    fn neon_premultiply_matches_scalar_reference() {
+        for bit_depth in [10usize, 12, 16, 14] {
+            for pixels in [1usize, 4, 17, 256] {
+                let mut rng = XorShiftRng::new(0xA11CE ^ (bit_depth as u64) << 32 ^ pixels as u64);
+                let src = make_rgba(&mut rng, pixels, bit_depth);
+
+                let mut dst_scalar = vec![0u16; pixels * 4];
+                let mut dst_neon = vec![0u16; pixels * 4];
+                premultiply_alpha_rgba_row(&mut dst_scalar, &src, bit_depth);
+                neon_premultiply_alpha_rgba_u16(&mut dst_neon, &src, bit_depth);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "bit_depth {bit_depth}, {pixels} pixels: NEON premultiply diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: zeroes RGB when alpha==0, but the scalar u16 unpremultiply path leaves RGB untouched in that case (u8 scalar path does zero it - inconsistent across bit depths) - see issue"]
+    #[test]
+    fn neon_unpremultiply_matches_scalar_reference() {
+        for bit_depth in [10usize, 12, 16, 14] {
+            for pixels in [1usize, 4, 17, 256] {
+                let mut rng = XorShiftRng::new(0xB0BA ^ (bit_depth as u64) << 32 ^ pixels as u64);
+                let src = make_rgba(&mut rng, pixels, bit_depth);
+
+                let mut scalar_buf = src.clone();
+                let mut neon_buf = src;
+                unpremultiply_alpha_rgba_row(&mut scalar_buf, bit_depth);
+                neon_unpremultiply_alpha_rgba_u16(&mut neon_buf, bit_depth);
+
+                assert_eq!(
+                    scalar_buf, neon_buf,
+                    "bit_depth {bit_depth}, {pixels} pixels: NEON unpremultiply diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/alpha_u8.rs
+++ b/src/neon/alpha_u8.rs
@@ -364,3 +364,63 @@ pub(crate) fn neon_unpremultiply_alpha_rgba(in_place: &mut [u8], _strategy: Work
         _executor(in_place);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::alpha_handle_u8::{
+        premultiply_alpha_rgba_row_impl, unpremultiply_alpha_rgba_row_impl,
+    };
+    use crate::test_utils::XorShiftRng;
+
+    /// Builds an RGBA8 buffer that mixes alpha == 0, alpha == 255 and fully
+    /// random pixels so both the vectorized bulk path and the scalar tail
+    /// remainder exercise the branches the premultiply/unpremultiply math
+    /// takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<u8> {
+        let mut buf = rng.fill_u8(pixels * 4);
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 255;
+        }
+        buf
+    }
+
+    #[test]
+    fn neon_premultiply_matches_scalar_reference() {
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0u8; pixels * 4];
+            let mut dst_neon = vec![0u8; pixels * 4];
+            premultiply_alpha_rgba_row_impl(&mut dst_scalar, &src);
+            neon_premultiply_alpha_rgba(&mut dst_neon, &src);
+
+            assert_eq!(
+                dst_scalar, dst_neon,
+                "{pixels} pixels: NEON premultiply diverges from the scalar reference"
+            );
+        }
+    }
+
+    #[test]
+    fn neon_unpremultiply_matches_scalar_reference() {
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut neon_buf = src;
+            unpremultiply_alpha_rgba_row_impl(&mut scalar_buf);
+            neon_unpremultiply_alpha_rgba(&mut neon_buf, WorkloadStrategy::PreferSpeed);
+
+            assert_eq!(
+                scalar_buf, neon_buf,
+                "{pixels} pixels: NEON unpremultiply diverges from the scalar reference"
+            );
+        }
+    }
+}

--- a/src/neon/cbcr8.rs
+++ b/src/neon/cbcr8.rs
@@ -279,3 +279,76 @@ fn convolve_horizontal_cbcr_neon_row_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 2);
+
+                let mut dst_scalar = vec![0u8; out_size * 2];
+                let mut dst_neon = vec![0u8; out_size * 2];
+                handle_fixed_row_u8::<2>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_cbcr_neon_row(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON cbcr single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 2;
+                let dst_stride = out_size * 2;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_neon = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<2>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_cbcr_neon_rows_4_u8(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON cbcr 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/cbcr8_dot.rs
+++ b/src/neon/cbcr8_dot.rs
@@ -322,3 +322,124 @@ fn convolve_horizontal_cbcr_neon_dot_row_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    /// The i8mm dot-product path quantizes weights to Q0.7 (via
+    /// `FilterWeights::numerical_approximation_q0_7`) instead of the Q15 `i16`
+    /// weights every other u8 backend in this crate uses, so `handler_provider`'s
+    /// scalar reference (which expects Q15 weights) can't be reused bit-exact
+    /// here. Reimplement the same Q0.7 arithmetic `store_cbcr` performs: an i32
+    /// accumulator with a rounding bias of `1 << 6`, then `>> 7`, clamped to
+    /// `u8` range (mirrors the two-stage saturating narrow `vqshrun_n_s32::<7>`
+    /// + `vqmovn_u16` perform in hardware).
+    fn scalar_reference_cbcr_dot_row(
+        src: &[u8],
+        dst: &mut [u8],
+        filter_weights: &FilterWeights<i8>,
+    ) {
+        const CN: usize = 2;
+        const ROUNDING: i32 = 1 << 6;
+        for (dst_px, (&bounds, weights)) in dst.as_chunks_mut::<CN>().0.iter_mut().zip(
+            filter_weights
+                .bounds
+                .iter()
+                .zip(filter_weights.weights.chunks_exact(filter_weights.aligned_size)),
+        ) {
+            let mut acc = [ROUNDING; CN];
+            for k in 0..bounds.size {
+                let w = weights[k] as i32;
+                let src_px = &src[(bounds.start + k) * CN..];
+                for (c, acc_c) in acc.iter_mut().enumerate() {
+                    *acc_c += w * src_px[c] as i32;
+                }
+            }
+            for (c, dst_c) in dst_px.iter_mut().enumerate() {
+                *dst_c = (acc[c] >> 7).clamp(0, 255) as u8;
+            }
+        }
+    }
+
+    fn make_row_filter_weights_q0_7(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> FilterWeights<i8> {
+        let weights_f32 =
+            <u8 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation_q0_7(0)
+    }
+
+    #[test]
+    fn neon_dot_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("i8mm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights = make_row_filter_weights_q0_7(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 2);
+
+                let mut dst_scalar = vec![0u8; out_size * 2];
+                let mut dst_dot = vec![0u8; out_size * 2];
+                scalar_reference_cbcr_dot_row(&src, &mut dst_scalar, &filter_weights);
+                convolve_horizontal_cbcr_neon_dot_row(&src, &mut dst_dot, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_dot,
+                    "{resampling:?} {in_size}->{out_size}: NEON i8mm dot cbcr single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_dot_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("i8mm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights = make_row_filter_weights_q0_7(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 2;
+                let dst_stride = out_size * 2;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_dot = vec![0u8; dst_stride * ROWS];
+                for row in 0..ROWS {
+                    scalar_reference_cbcr_dot_row(
+                        &src[row * src_stride..],
+                        &mut dst_scalar[row * dst_stride..(row + 1) * dst_stride],
+                        &filter_weights,
+                    );
+                }
+                convolve_horizontal_cbcr_neon_rows_dot_4_u8(
+                    &src,
+                    src_stride,
+                    &mut dst_dot,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_dot,
+                    "{resampling:?} {in_size}->{out_size}: NEON i8mm dot cbcr 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/cbcr8_rdm.rs
+++ b/src/neon/cbcr8_rdm.rs
@@ -345,3 +345,84 @@ fn convolve_horizontal_cbcr_neon_rdm_row_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[ignore = "known bug: NEON RDM (rounding doubling multiply) path has a small rounding divergence from the scalar reference - see issue"]
+    #[test]
+    fn neon_rdm_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 2);
+
+                let mut dst_scalar = vec![0u8; out_size * 2];
+                let mut dst_rdm = vec![0u8; out_size * 2];
+                handle_fixed_row_u8::<2>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_cbcr_neon_rdm_row(&src, &mut dst_rdm, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_rdm,
+                    "{resampling:?} {in_size}->{out_size}: NEON RDM cbcr single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: NEON RDM (rounding doubling multiply) path has a small rounding divergence from the scalar reference - see issue"]
+    #[test]
+    fn neon_rdm_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 2;
+                let dst_stride = out_size * 2;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_rdm = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<2>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_cbcr_neon_rows_rdm_4_u8(
+                    &src,
+                    src_stride,
+                    &mut dst_rdm,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_rdm,
+                    "{resampling:?} {in_size}->{out_size}: NEON RDM cbcr 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/cbcr_u16.rs
+++ b/src/neon/cbcr_u16.rs
@@ -326,3 +326,85 @@ pub(crate) fn convolve_horizontal_cbcr_neon_f32_u16_row(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_horizontal::{
+        convolve_row_handler_floating_point, convolve_row_handler_floating_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        const CN: usize = 2;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * CN, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * CN];
+                let mut dst_neon = vec![0u16; out_size * CN];
+                convolve_row_handler_floating_point::<u16, f32, f32, CN>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    16,
+                );
+                convolve_horizontal_cbcr_neon_f32_u16_row(&src, &mut dst_neon, &filter_weights, 16);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const CN: usize = 2;
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * CN;
+                let dst_stride = out_size * CN;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, CN>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    16,
+                );
+                convolve_horizontal_cbcr_neon_rows_4_f32_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    16,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/cbcr_u16_lb.rs
+++ b/src/neon/cbcr_u16_lb.rs
@@ -295,3 +295,92 @@ pub(crate) fn convolve_horizontal_gray_alpha_neon_u16_lb_row(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        const CN: usize = 2;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * CN, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; out_size * CN];
+                let mut dst_neon = vec![0u16; out_size * CN];
+                convolve_row_handler_fixed_point::<u16, i32, CN>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_gray_alpha_neon_u16_lb_row(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const CN: usize = 2;
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * CN;
+                let dst_stride = out_size * CN;
+                let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<u16, i32, CN>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_gray_alpha_neon_rows_4_lb_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_f32.rs
+++ b/src/neon/plane_f32.rs
@@ -307,3 +307,88 @@ pub(crate) fn convolve_horizontal_plane_neon_rows_4(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32,
+    };
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // Same reduction-reordering + hardware-FMA rationale as sse/plane_f32.rs
+    // and avx2/plane_f32.rs: a single-channel plane accumulates multiple taps
+    // per SIMD lane and reduces at the end, unlike the scalar loop's strict
+    // left-to-right accumulation - not bit-exact (observed diffs are 1 ULP).
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size);
+
+                let mut dst_scalar = vec![0f32; out_size];
+                let mut dst_neon = vec![0f32; out_size];
+                convolve_horizontal_native_row_f32::<1>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_plane_neon_row_one(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON plane f32 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_neon = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_plane_neon_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON plane f32 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_f32_f64.rs
+++ b/src/neon/plane_f32_f64.rs
@@ -193,3 +193,106 @@ pub(crate) fn convolve_horizontal_plane_neon_rows_4_f32_f64(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_4_row_f32_f64, convolve_horizontal_native_row_f32_f64,
+    };
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    /// See the identical helper in `src/avx2/plane_f32_f64.rs` - `PreferQuality`
+    /// weights are `f64`, which `test_utils` doesn't build a helper for.
+    fn make_row_filter_weights_f64(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<f64>, PicScaleError> {
+        <f32 as WeightsGenerator<f64>>::make_weights(resampling, in_size, out_size)
+    }
+
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size);
+
+                let mut dst_scalar = vec![0f32; out_size];
+                let mut dst_neon = vec![0f32; out_size];
+                convolve_horizontal_native_row_f32_f64::<1>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_plane_neon_row_one_f32_f64(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON plane f32/f64 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_neon = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_4_row_f32_f64::<1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_plane_neon_rows_4_f32_f64(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON plane f32/f64 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_s16_hb.rs
+++ b/src/neon/plane_s16_hb.rs
@@ -292,3 +292,159 @@ fn convolve_horizontal_plane_neon_s16_hb_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    const BIT_DEPTH: u32 = 10;
+
+    fn make_row_filter_weights_i16_q31(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<i32>, PicScaleError> {
+        let weights_f32 = <i16 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size)?;
+        Ok(weights_f32.numerical_approximation::<i32, 31>(0))
+    }
+
+    fn fill_i16_signed(rng: &mut XorShiftRng, len: usize, bit_depth: u32) -> Vec<i16> {
+        let max_unsigned = (1u16 << bit_depth) - 1;
+        rng.fill_u16(len, max_unsigned)
+            .into_iter()
+            .map(|v| (v as i32 - (1i32 << (bit_depth - 1))) as i16)
+            .collect()
+    }
+
+    /// Mirrors the `SQRDMLAH` fixed-point semantics used by the NEON `rdm`
+    /// intrinsics in this file: `result = round((2 * a * b) / 2^32)`, matching
+    /// ARM's rounding-doubling-multiply-high definition.
+    fn sqrdmulh(a: i32, b: i32) -> i32 {
+        let prod = (a as i64) * (b as i64);
+        let rounded = (prod.wrapping_mul(2).wrapping_add(1i64 << 31)) >> 32;
+        rounded.clamp(i32::MIN as i64, i32::MAX as i64) as i32
+    }
+
+    fn scalar_reference_row(src: &[i16], dst: &mut [i16], filter_weights: &FilterWeights<i32>, bit_depth: u32) {
+        let max_colors = (1i32 << (bit_depth - 1)) - 1;
+        let min_colors = -(1i32 << (bit_depth - 1));
+        for ((dst, &bounds), weights) in dst.iter_mut().zip(filter_weights.bounds.iter()).zip(
+            filter_weights
+                .weights
+                .chunks_exact(filter_weights.aligned_size),
+        ) {
+            let mut acc: i32 = 1 << 5;
+            let start_x = bounds.start;
+            for (i, &w) in weights[..bounds.size].iter().enumerate() {
+                let pixel = src[start_x + i] as i32;
+                let a = pixel << 6;
+                acc += sqrdmulh(a, w);
+            }
+            let shifted = (acc >> 6).clamp(i16::MIN as i32, i16::MAX as i32);
+            *dst = shifted.clamp(min_colors, max_colors) as i16;
+        }
+    }
+
+    fn scalar_reference_rows_4(
+        src: &[i16],
+        src_stride: usize,
+        dst: &mut [i16],
+        dst_stride: usize,
+        filter_weights: &FilterWeights<i32>,
+        bit_depth: u32,
+    ) {
+        let (row0, rest) = dst.split_at_mut(dst_stride);
+        let (row1, rest) = rest.split_at_mut(dst_stride);
+        let (row2, row3) = rest.split_at_mut(dst_stride);
+        scalar_reference_row(src, row0, filter_weights, bit_depth);
+        scalar_reference_row(&src[src_stride..], row1, filter_weights, bit_depth);
+        scalar_reference_row(&src[src_stride * 2..], row2, filter_weights, bit_depth);
+        scalar_reference_row(&src[src_stride * 3..], row3, filter_weights, bit_depth);
+    }
+
+    // NOTE: this is a NEON-only `rdm` acceleration path with no generic
+    // crate-wide scalar reference (`fixed_point_horizontal` hardcodes Q15
+    // `FilterWeights<i16>`), so `scalar_reference_row`/`_rows_4` above
+    // reimplement the Q31 SQRDMLAH arithmetic by hand. This can only be
+    // type-checked on x86_64, not executed - it must be run on real aarch64
+    // hardware with `rdm` to confirm correctness.
+
+    #[test]
+    #[cfg(feature = "rdm")]
+    fn neon_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const CN: usize = 1;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_i16_q31(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = fill_i16_signed(&mut rng, in_size * CN, BIT_DEPTH);
+
+                let mut dst_scalar = vec![0i16; out_size * CN];
+                let mut dst_neon = vec![0i16; out_size * CN];
+                scalar_reference_row(&src, &mut dst_scalar, &filter_weights, BIT_DEPTH);
+                convolve_horizontal_plane_neon_s16_hb_row(&src, &mut dst_neon, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "rdm")]
+    fn neon_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const CN: usize = 1;
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_i16_q31(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * CN;
+                let dst_stride = out_size * CN;
+                let src = fill_i16_signed(&mut rng, src_stride * ROWS, BIT_DEPTH);
+
+                let mut dst_scalar = vec![0i16; dst_stride * ROWS];
+                let mut dst_neon = vec![0i16; dst_stride * ROWS];
+                scalar_reference_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_neon_rows_4_hb_s16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_s16_lb.rs
+++ b/src/neon/plane_s16_lb.rs
@@ -255,3 +255,115 @@ pub(crate) fn convolve_horizontal_plane_neon_i16_lb_row(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::filter_weights::FilterWeights;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::math::WeightsGenerator;
+    use crate::support::PRECISION;
+    use crate::test_utils::XorShiftRng;
+
+    const BIT_DEPTH: u32 = 10;
+
+    fn make_row_filter_weights_i16(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<i16>, PicScaleError> {
+        let weights_f32 = <i16 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size)?;
+        Ok(weights_f32.numerical_approximation::<i16, PRECISION>(0))
+    }
+
+    /// Signed source pixels centered near zero within `bit_depth`'s signed
+    /// range, matching how `i16` plane data is actually represented.
+    fn fill_i16_signed(rng: &mut XorShiftRng, len: usize, bit_depth: u32) -> Vec<i16> {
+        let max_unsigned = (1u16 << bit_depth) - 1;
+        rng.fill_u16(len, max_unsigned)
+            .into_iter()
+            .map(|v| (v as i32 - (1i32 << (bit_depth - 1))) as i16)
+            .collect()
+    }
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        const CN: usize = 1;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_i16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = fill_i16_signed(&mut rng, in_size * CN, BIT_DEPTH);
+
+                let mut dst_scalar = vec![0i16; out_size * CN];
+                let mut dst_neon = vec![0i16; out_size * CN];
+                convolve_row_handler_fixed_point::<i16, i32, CN>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_neon_i16_lb_row(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const CN: usize = 1;
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_i16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * CN;
+                let dst_stride = out_size * CN;
+                let src = fill_i16_signed(&mut rng, src_stride * ROWS, BIT_DEPTH);
+
+                let mut dst_scalar = vec![0i16; dst_stride * ROWS];
+                let mut dst_neon = vec![0i16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<i16, i32, CN>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_neon_rows_4_lb_i16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_u16.rs
+++ b/src/neon/plane_u16.rs
@@ -301,3 +301,87 @@ fn convolve_horizontal_plane_neon_f32_u16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_horizontal::{
+        convolve_row_handler_floating_point, convolve_row_handler_floating_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        const CN: usize = 1;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * CN, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * CN];
+                let mut dst_neon = vec![0u16; out_size * CN];
+                convolve_row_handler_floating_point::<u16, f32, f32, CN>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    16,
+                );
+                convolve_horizontal_plane_neon_f32_u16_row(&src, &mut dst_neon, &filter_weights, 16);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const CN: usize = 1;
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * CN;
+                let dst_stride = out_size * CN;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, CN>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    16,
+                );
+                convolve_horizontal_plane_neon_rows_4_f32_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    16,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_u16_hb.rs
+++ b/src/neon/plane_u16_hb.rs
@@ -304,3 +304,150 @@ fn convolve_horizontal_plane_neon_u16_hb_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    const BIT_DEPTH: u32 = 16;
+
+    fn make_row_filter_weights_u16_q31(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<i32>, PicScaleError> {
+        let weights_f32 = <u16 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size)?;
+        Ok(weights_f32.numerical_approximation::<i32, 31>(0))
+    }
+
+    /// Mirrors the `SQRDMLAH` fixed-point semantics used by the NEON `rdm`
+    /// intrinsics in this file: `result = round((2 * a * b) / 2^32)`, matching
+    /// ARM's rounding-doubling-multiply-high definition.
+    fn sqrdmulh(a: i32, b: i32) -> i32 {
+        let prod = (a as i64) * (b as i64);
+        let rounded = (prod.wrapping_mul(2).wrapping_add(1i64 << 31)) >> 32;
+        rounded.clamp(i32::MIN as i64, i32::MAX as i64) as i32
+    }
+
+    fn scalar_reference_row(src: &[u16], dst: &mut [u16], filter_weights: &FilterWeights<i32>, bit_depth: u32) {
+        let max_colors = (1u32 << bit_depth) - 1;
+        for ((dst, &bounds), weights) in dst.iter_mut().zip(filter_weights.bounds.iter()).zip(
+            filter_weights
+                .weights
+                .chunks_exact(filter_weights.aligned_size),
+        ) {
+            let mut acc: i32 = 1 << 5;
+            let start_x = bounds.start;
+            for (i, &w) in weights[..bounds.size].iter().enumerate() {
+                let pixel = src[start_x + i] as i32;
+                let a = pixel << 6;
+                acc += sqrdmulh(a, w);
+            }
+            let shifted = (acc >> 6).clamp(0, u16::MAX as i32) as u32;
+            *dst = shifted.min(max_colors) as u16;
+        }
+    }
+
+    fn scalar_reference_rows_4(
+        src: &[u16],
+        src_stride: usize,
+        dst: &mut [u16],
+        dst_stride: usize,
+        filter_weights: &FilterWeights<i32>,
+        bit_depth: u32,
+    ) {
+        let (row0, rest) = dst.split_at_mut(dst_stride);
+        let (row1, rest) = rest.split_at_mut(dst_stride);
+        let (row2, row3) = rest.split_at_mut(dst_stride);
+        scalar_reference_row(src, row0, filter_weights, bit_depth);
+        scalar_reference_row(&src[src_stride..], row1, filter_weights, bit_depth);
+        scalar_reference_row(&src[src_stride * 2..], row2, filter_weights, bit_depth);
+        scalar_reference_row(&src[src_stride * 3..], row3, filter_weights, bit_depth);
+    }
+
+    // NOTE: this is a NEON-only `rdm` acceleration path with no generic
+    // crate-wide scalar reference (`fixed_point_horizontal` hardcodes Q15
+    // `FilterWeights<i16>`), so `scalar_reference_row`/`_rows_4` above
+    // reimplement the Q31 SQRDMLAH arithmetic by hand. This can only be
+    // type-checked on x86_64, not executed - it must be run on real aarch64
+    // hardware with `rdm` to confirm correctness.
+
+    #[test]
+    #[cfg(feature = "rdm")]
+    fn neon_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const CN: usize = 1;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16_q31(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * CN, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * CN];
+                let mut dst_neon = vec![0u16; out_size * CN];
+                scalar_reference_row(&src, &mut dst_scalar, &filter_weights, BIT_DEPTH);
+                convolve_horizontal_plane_neon_u16_hb_row(&src, &mut dst_neon, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "rdm")]
+    fn neon_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const CN: usize = 1;
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16_q31(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * CN;
+                let dst_stride = out_size * CN;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                scalar_reference_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_neon_rows_4_hb_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_u16_lb.rs
+++ b/src/neon/plane_u16_lb.rs
@@ -261,3 +261,92 @@ pub(crate) fn convolve_horizontal_plane_neon_u16_lb_row(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        const CN: usize = 1;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * CN, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; out_size * CN];
+                let mut dst_neon = vec![0u16; out_size * CN];
+                convolve_row_handler_fixed_point::<u16, i32, CN>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_neon_u16_lb_row(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const CN: usize = 1;
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * CN;
+                let dst_stride = out_size * CN;
+                let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<u16, i32, CN>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_plane_neon_rows_4_lb_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_u8.rs
+++ b/src/neon/plane_u8.rs
@@ -334,3 +334,76 @@ fn convolve_horizontal_plane_neon_row_impl<const D: bool, const PRECISION: i32>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size);
+
+                let mut dst_scalar = vec![0u8; out_size];
+                let mut dst_neon = vec![0u8; out_size];
+                handle_fixed_row_u8::<1>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_plane_neon_row(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON plane single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_neon = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_plane_neon_rows_4_u8(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON plane 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/plane_u8_rdm.rs
+++ b/src/neon/plane_u8_rdm.rs
@@ -381,3 +381,84 @@ fn convolve_horizontal_plane_neon_rdm_row_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[ignore = "known bug: NEON RDM (rounding doubling multiply) path has a small rounding divergence from the scalar reference - see issue"]
+    #[test]
+    fn neon_rdm_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size);
+
+                let mut dst_scalar = vec![0u8; out_size];
+                let mut dst_rdm = vec![0u8; out_size];
+                handle_fixed_row_u8::<1>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_plane_neon_rdm_row(&src, &mut dst_rdm, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_rdm,
+                    "{resampling:?} {in_size}->{out_size}: NEON RDM plane single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: NEON RDM (rounding doubling multiply) path has a small rounding divergence from the scalar reference - see issue"]
+    #[test]
+    fn neon_rdm_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_rdm = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_plane_neon_rows_rdm_4_u8(
+                    &src,
+                    src_stride,
+                    &mut dst_rdm,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_rdm,
+                    "{resampling:?} {in_size}->{out_size}: NEON RDM plane 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_f16.rs
+++ b/src/neon/rgb_f16.rs
@@ -295,3 +295,89 @@ fn convolve_horizontal_rgb_neon_row_one_f16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // NEON uses hardware FMA, which fuses/re-rounds relative to the scalar
+    // loop's separate multiply-then-add - not bit-exact.
+    const ATOL: f32 = 1e-3;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f16; out_size * 3];
+                let mut dst_neon = vec![0f16; out_size * 3];
+                convolve_horizontal_rgb_native_row_f16::<3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_neon_row_one_f16(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON rgb f16 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_neon = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_neon_rows_4_f16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON rgb f16 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_f16_fhm.rs
+++ b/src/neon/rgb_f16_fhm.rs
@@ -300,3 +300,106 @@ fn convolve_horizontal_rgb_neon_row_one_f16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::filter_weights::{WeightFloat16Converter, WeightsConverter};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // The `fhm` path widens f16 taps through `vfmlal`, which accumulates in
+    // f32 but the weights themselves are pre-quantized to f16 - not
+    // bit-exact against the scalar f32-weighted reference.
+    const ATOL: f32 = 5e-2;
+
+    #[test]
+    fn neon_fhm_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fhm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights_f32 =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let filter_weights_f16 =
+                    WeightFloat16Converter::default().prepare_weights(&filter_weights_f32);
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f16; out_size * 3];
+                let mut dst_neon = vec![0f16; out_size * 3];
+                convolve_horizontal_rgb_native_row_f16::<3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights_f32,
+                    8,
+                );
+                convolve_horizontal_rgb_neon_row_one_f16_fhm(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights_f16,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON fhm rgb f16 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_fhm_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fhm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights_f32 =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let filter_weights_f16 =
+                    WeightFloat16Converter::default().prepare_weights(&filter_weights_f32);
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_neon = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights_f32,
+                    8,
+                );
+                convolve_horizontal_rgb_neon_rows_4_f16_fhm(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights_f16,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON fhm rgb f16 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_f16_full.rs
+++ b/src/neon/rgb_f16_full.rs
@@ -300,3 +300,96 @@ fn xconvolve_horizontal_rgb_neon_row_one_f16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // The "full" fp16 path accumulates natively in f16 (`vfma_f16`), which has
+    // far fewer significand bits than the scalar f32 accumulation - not
+    // bit-exact, and needs a looser tolerance than the f32-accumulating paths.
+    const ATOL: f32 = 5e-2;
+
+    #[test]
+    fn neon_fp16_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f16; out_size * 3];
+                let mut dst_neon = vec![0f16; out_size * 3];
+                convolve_horizontal_rgb_native_row_f16::<3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                xconvolve_horizontal_rgb_neon_row_one_f16(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON fp16 rgb f16 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_fp16_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_neon = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                xconvolve_horizontal_rgb_neon_rows_4_f16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON fp16 rgb f16 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_f32.rs
+++ b/src/neon/rgb_f32.rs
@@ -233,3 +233,83 @@ pub(crate) fn convolve_horizontal_rgb_neon_row_one_f32(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32};
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // Same FMA-rounding rationale as neon/rgba_f32.rs.
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f32; out_size * 3];
+                let mut dst_neon = vec![0f32; out_size * 3];
+                convolve_horizontal_native_row_f32::<3>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgb_neon_row_one_f32(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON RGB f32 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_neon = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_neon_rows_4_f32(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON RGB f32 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_f32_f64.rs
+++ b/src/neon/rgb_f32_f64.rs
@@ -238,3 +238,106 @@ pub(crate) fn convolve_horizontal_rgb_neon_row_one_f32_f64(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_4_row_f32_f64, convolve_horizontal_native_row_f32_f64,
+    };
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    /// See the identical helper in `src/avx2/plane_f32_f64.rs` - `PreferQuality`
+    /// weights are `f64`, which `test_utils` doesn't build a helper for.
+    fn make_row_filter_weights_f64(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<f64>, PicScaleError> {
+        <f32 as WeightsGenerator<f64>>::make_weights(resampling, in_size, out_size)
+    }
+
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f32; out_size * 3];
+                let mut dst_neon = vec![0f32; out_size * 3];
+                convolve_horizontal_native_row_f32_f64::<3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_neon_row_one_f32_f64(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON rgb f32/f64 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_neon = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_4_row_f32_f64::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_neon_rows_4_f32_f64(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON rgb f32/f64 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_u16.rs
+++ b/src/neon/rgb_u16.rs
@@ -291,3 +291,85 @@ fn convolve_horizontal_rgb_neon_u16_hb_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_horizontal::{
+        convolve_row_handler_floating_point, convolve_row_handler_floating_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    const BIT_DEPTH: u32 = 16;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 3, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * 3];
+                let mut dst_neon = vec![0u16; out_size * 3];
+                convolve_row_handler_floating_point::<u16, f32, f32, 3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_neon_u16_row_f32(&src, &mut dst_neon, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, 3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_neon_rows_4_u16_f32(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_u16_hb.rs
+++ b/src/neon/rgb_u16_hb.rs
@@ -316,3 +316,154 @@ fn convolve_horizontal_rgb_neon_u16_hb_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    const BIT_DEPTH: u32 = 16;
+
+    fn make_row_filter_weights_u16_q31(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> FilterWeights<i32> {
+        let weights_f32 = <u16 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation::<i32, 31>(0)
+    }
+
+    /// Scalar model of ARM's `SQRDMLAH`/`SQRDMULH`: `round(2*a*b / 2^32)`,
+    /// matching the `vqrdmlahq_s32` accumulation the real NEON `_hb` kernel
+    /// uses (saturation only differs at the a=b=i32::MIN corner, unreachable
+    /// here).
+    fn sqrdmulh(a: i32, b: i32) -> i32 {
+        let prod = 2i64 * (a as i64) * (b as i64) + (1i64 << 31);
+        (prod >> 32) as i32
+    }
+
+    fn scalar_ref_hb_row<const CN: usize>(
+        src: &[u16],
+        dst: &mut [u16],
+        filter_weights: &FilterWeights<i32>,
+        bit_depth: u32,
+    ) {
+        let max_colors = (1i32 << bit_depth) - 1;
+        for ((chunk, &bounds), weights) in dst
+            .as_chunks_mut::<CN>()
+            .0
+            .iter_mut()
+            .zip(filter_weights.bounds.iter())
+            .zip(
+                filter_weights
+                    .weights
+                    .chunks_exact(filter_weights.aligned_size),
+            )
+        {
+            let mut acc = [1i32 << 5; CN];
+            let px = bounds.start * CN;
+            let src_chunk = &src[px..(px + bounds.size * CN)];
+            for (&w, src_px) in weights[..bounds.size]
+                .iter()
+                .zip(src_chunk.as_chunks::<CN>().0.iter())
+            {
+                for c in 0..CN {
+                    let a = (src_px[c] as i32) << 6;
+                    acc[c] += sqrdmulh(a, w);
+                }
+            }
+            for c in 0..CN {
+                chunk[c] = (acc[c] >> 6).clamp(0, max_colors) as u16;
+            }
+        }
+    }
+
+    fn scalar_ref_hb_rows_4<const CN: usize>(
+        src: &[u16],
+        src_stride: usize,
+        dst: &mut [u16],
+        dst_stride: usize,
+        filter_weights: &FilterWeights<i32>,
+        bit_depth: u32,
+    ) {
+        let (row0, rest) = dst.split_at_mut(dst_stride);
+        let (row1, rest) = rest.split_at_mut(dst_stride);
+        let (row2, row3) = rest.split_at_mut(dst_stride);
+        for (row, offset) in [(row0, 0), (row1, src_stride), (row2, src_stride * 2), (row3, src_stride * 3)] {
+            scalar_ref_hb_row::<CN>(&src[offset..], row, filter_weights, bit_depth);
+        }
+    }
+
+    #[cfg(feature = "rdm")]
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights = make_row_filter_weights_u16_q31(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 3, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * 3];
+                let mut dst_neon = vec![0u16; out_size * 3];
+                scalar_ref_hb_row::<3>(&src, &mut dst_scalar, &filter_weights, BIT_DEPTH);
+                convolve_horizontal_rgb_neon_u16_hb_row(&src, &mut dst_neon, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON RDM single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "rdm")]
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights = make_row_filter_weights_u16_q31(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                scalar_ref_hb_rows_4::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_neon_rows_4_hb_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON RDM 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_u16_lb.rs
+++ b/src/neon/rgb_u16_lb.rs
@@ -326,3 +326,85 @@ pub(crate) fn convolve_horizontal_rgb_neon_u16_lb_row(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 3, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; out_size * 3];
+                let mut dst_neon = vec![0u16; out_size * 3];
+                convolve_row_handler_fixed_point::<u16, i32, 3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_neon_u16_lb_row(&src, &mut dst_neon, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<u16, i32, 3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgb_neon_rows_4_lb_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_u8.rs
+++ b/src/neon/rgb_u8.rs
@@ -299,3 +299,76 @@ fn convolve_horizontal_rgb_neon_row_one_impl<const D: bool, const PRECISION: i32
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 3);
+
+                let mut dst_scalar = vec![0u8; out_size * 3];
+                let mut dst_neon = vec![0u8; out_size * 3];
+                handle_fixed_row_u8::<3>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgb_neon_row_one(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON RGB single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_neon = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_neon_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON RGB 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_u8_dot.rs
+++ b/src/neon/rgb_u8_dot.rs
@@ -289,3 +289,120 @@ fn convolve_horizontal_rgb_neon_row_one_impl_dot(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    /// The i8mm dot-product path quantizes weights to Q0.7 (via
+    /// `FilterWeights::numerical_approximation_q0_7`) instead of the Q15 `i16`
+    /// weights the base NEON rgb path uses, so `handler_provider`'s scalar
+    /// reference (which expects Q15 weights) can't be reused bit-exact here.
+    /// Reimplement the same Q0.7 arithmetic the hardware performs: an i32
+    /// accumulator per channel with a rounding bias of `1 << 6`, then `>> 7`,
+    /// clamped to `u8` range (mirrors `vusdotq_s32` + `vqshrun_n_s32::<7>` +
+    /// `vqmovn_u16`).
+    fn scalar_reference_rgb_dot_row(src: &[u8], dst: &mut [u8], filter_weights: &FilterWeights<i8>) {
+        const CN: usize = 3;
+        const ROUNDING: i32 = 1 << 6;
+        for (dst_px, (&bounds, weights)) in dst.as_chunks_mut::<CN>().0.iter_mut().zip(
+            filter_weights
+                .bounds
+                .iter()
+                .zip(filter_weights.weights.chunks_exact(filter_weights.aligned_size)),
+        ) {
+            let mut acc = [ROUNDING; CN];
+            for k in 0..bounds.size {
+                let w = weights[k] as i32;
+                let src_px = &src[(bounds.start + k) * CN..];
+                for (c, acc_c) in acc.iter_mut().enumerate() {
+                    *acc_c += w * src_px[c] as i32;
+                }
+            }
+            for (c, dst_c) in dst_px.iter_mut().enumerate() {
+                *dst_c = (acc[c] >> 7).clamp(0, 255) as u8;
+            }
+        }
+    }
+
+    fn make_row_filter_weights_q0_7(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> FilterWeights<i8> {
+        let weights_f32 =
+            <u8 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation_q0_7(0)
+    }
+
+    #[test]
+    fn neon_dot_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("i8mm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights = make_row_filter_weights_q0_7(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 3);
+
+                let mut dst_scalar = vec![0u8; out_size * 3];
+                let mut dst_dot = vec![0u8; out_size * 3];
+                scalar_reference_rgb_dot_row(&src, &mut dst_scalar, &filter_weights);
+                convolve_horizontal_rgb_neon_row_one_dot(&src, &mut dst_dot, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_dot,
+                    "{resampling:?} {in_size}->{out_size}: NEON i8mm dot rgb single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_dot_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("i8mm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights = make_row_filter_weights_q0_7(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_dot = vec![0u8; dst_stride * ROWS];
+                for row in 0..ROWS {
+                    scalar_reference_rgb_dot_row(
+                        &src[row * src_stride..],
+                        &mut dst_scalar[row * dst_stride..(row + 1) * dst_stride],
+                        &filter_weights,
+                    );
+                }
+                convolve_horizontal_rgb_neon_rows_4_dot(
+                    &src,
+                    src_stride,
+                    &mut dst_dot,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_dot,
+                    "{resampling:?} {in_size}->{out_size}: NEON i8mm dot rgb 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgb_u8_sqrdml.rs
+++ b/src/neon/rgb_u8_sqrdml.rs
@@ -344,3 +344,132 @@ fn convolve_horizontal_rgb_neon_row_rdm_one_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    // The `rdm` path keeps two independent i16 accumulators per channel
+    // inside one 8-lane register (lanes 0-2 for even-indexed taps, lanes 4-6
+    // for odd-indexed taps, folded together only in `write_accumulator_u8` at
+    // the very end), each updated with `vqrdmlahq_s16` - a *saturating*
+    // rounding-doubling-multiply-accumulate, not a plain widening MAC. That
+    // makes `handler_provider`'s i32-accumulator scalar reference unusable
+    // bit-exact here, so this reimplements the exact hardware arithmetic:
+    // pixels are widened to a 14-bit fixed representation the same way
+    // `expand8_to_14` does (`(byte * 257) >> 2`), each tap is folded in with
+    // the same rounding-doubling-multiply-high-add formula RDM uses, and the
+    // two per-channel accumulators are added (wrapping, like `vadd_s16`) only
+    // after every tap has been processed.
+    fn expand8_to_14(x: u8) -> i16 {
+        (((x as u32) * 257) >> 2) as i16
+    }
+
+    fn sqrdmlah_i16(acc: i16, a: i16, b: i16) -> i16 {
+        let product2 = 2i64 * (a as i64) * (b as i64);
+        let rounded = (product2 + (1i64 << 15)) >> 16;
+        (acc as i64 + rounded).clamp(i16::MIN as i64, i16::MAX as i64) as i16
+    }
+
+    fn scalar_reference_rgb_rdm_row(
+        src: &[u8],
+        dst: &mut [u8],
+        filter_weights: &FilterWeights<i16>,
+    ) {
+        const CN: usize = 3;
+        const ROUNDING: i16 = 1 << 5;
+        for (dst_px, (&bounds, weights)) in dst.as_chunks_mut::<CN>().0.iter_mut().zip(
+            filter_weights
+                .bounds
+                .iter()
+                .zip(filter_weights.weights.chunks_exact(filter_weights.aligned_size)),
+        ) {
+            let mut low = [ROUNDING; CN];
+            let mut high = [0i16; CN];
+            for k in 0..bounds.size {
+                let w = weights[k];
+                let src_px = &src[(bounds.start + k) * CN..];
+                let target = if k % 2 == 0 { &mut low } else { &mut high };
+                for c in 0..CN {
+                    target[c] = sqrdmlah_i16(target[c], expand8_to_14(src_px[c]), w);
+                }
+            }
+            for c in 0..CN {
+                let folded = low[c].wrapping_add(high[c]);
+                dst_px[c] = ((folded >> 6) as i32).clamp(0, 255) as u8;
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rdm_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 3);
+
+                let mut dst_scalar = vec![0u8; out_size * 3];
+                let mut dst_rdm = vec![0u8; out_size * 3];
+                scalar_reference_rgb_rdm_row(&src, &mut dst_scalar, &filter_weights);
+                convolve_horizontal_rgb_neon_rdm_row_one(&src, &mut dst_rdm, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_rdm,
+                    "{resampling:?} {in_size}->{out_size}: NEON rdm rgb single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rdm_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_rdm = vec![0u8; dst_stride * ROWS];
+                for row in 0..ROWS {
+                    scalar_reference_rgb_rdm_row(
+                        &src[row * src_stride..],
+                        &mut dst_scalar[row * dst_stride..(row + 1) * dst_stride],
+                        &filter_weights,
+                    );
+                }
+                convolve_horizontal_rgb_neon_rdm_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_rdm,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_rdm,
+                    "{resampling:?} {in_size}->{out_size}: NEON rdm rgb 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_f16.rs
+++ b/src/neon/rgba_f16.rs
@@ -369,3 +369,90 @@ pub(crate) fn convolve_horizontal_rgba_neon_rows_4_f16(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // NEON uses hardware FMA, which fuses/re-rounds relative to the scalar
+    // loop's separate multiply-then-add - not bit-exact.
+    const ATOL: f32 = 1e-3;
+
+    #[ignore = "known bug: off-by-one loop bound (jx <= bounds.size, should be <) causes an actual out-of-bounds read - confirmed via a real SIGABRT crash under qemu-aarch64, not just a suspected issue - see issue"]
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f16; out_size * 4];
+                let mut dst_neon = vec![0f16; out_size * 4];
+                convolve_horizontal_rgb_native_row_f16::<4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_neon_row_one_f16(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON f16 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_neon = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_neon_rows_4_f16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON f16 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_f16_fhm.rs
+++ b/src/neon/rgba_f16_fhm.rs
@@ -306,3 +306,106 @@ fn convolve_horizontal_rgba_neon_rows_4_f16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::filter_weights::{WeightFloat16Converter, WeightsConverter};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // The `fhm` path widens f16 taps through `vfmlal`, which accumulates in
+    // f32 but the weights themselves are pre-quantized to f16 - not
+    // bit-exact against the scalar f32-weighted reference.
+    const ATOL: f32 = 5e-2;
+
+    #[test]
+    fn neon_fhm_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fhm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights_f32 =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let filter_weights_f16 =
+                    WeightFloat16Converter::default().prepare_weights(&filter_weights_f32);
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f16; out_size * 4];
+                let mut dst_neon = vec![0f16; out_size * 4];
+                convolve_horizontal_rgb_native_row_f16::<4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights_f32,
+                    8,
+                );
+                convolve_horizontal_rgba_neon_row_one_f16_fhm(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights_f16,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON fhm f16 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_fhm_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fhm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights_f32 =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let filter_weights_f16 =
+                    WeightFloat16Converter::default().prepare_weights(&filter_weights_f32);
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_neon = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights_f32,
+                    8,
+                );
+                convolve_horizontal_rgba_neon_rows_4_f16_fhm(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights_f16,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON fhm f16 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_f16_full.rs
+++ b/src/neon/rgba_f16_full.rs
@@ -355,3 +355,96 @@ fn xconvolve_horizontal_rgba_neon_rows_4_f16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // The "full" fp16 path accumulates natively in f16 (`vfma_f16`), which has
+    // far fewer significand bits than the scalar f32 accumulation - not
+    // bit-exact, and needs a looser tolerance than the f32-accumulating paths.
+    const ATOL: f32 = 5e-2;
+
+    #[test]
+    fn neon_fp16_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f16; out_size * 4];
+                let mut dst_neon = vec![0f16; out_size * 4];
+                convolve_horizontal_rgb_native_row_f16::<4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                xconvolve_horizontal_rgba_neon_row_one_f16(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON fp16 f16 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_fp16_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_neon = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                xconvolve_horizontal_rgba_neon_rows_4_f16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON fp16 f16 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_f32.rs
+++ b/src/neon/rgba_f32.rs
@@ -262,3 +262,84 @@ pub(crate) fn convolve_horizontal_rgba_neon_rows_4(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32};
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // NEON uses hardware FMA (`vfmaq_f32`), which fuses/re-rounds relative to
+    // the scalar loop's separate multiply-then-add - not bit-exact.
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f32; out_size * 4];
+                let mut dst_neon = vec![0f32; out_size * 4];
+                convolve_horizontal_native_row_f32::<4>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgba_neon_row_one(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON f32 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_neon = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_neon_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON f32 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_f32_f64.rs
+++ b/src/neon/rgba_f32_f64.rs
@@ -241,3 +241,106 @@ pub(crate) fn convolve_horizontal_rgba_neon_rows_4_f32_f64(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::PicScaleError;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_4_row_f32_f64, convolve_horizontal_native_row_f32_f64,
+    };
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    /// See the identical helper in `src/avx2/plane_f32_f64.rs` - `PreferQuality`
+    /// weights are `f64`, which `test_utils` doesn't build a helper for.
+    fn make_row_filter_weights_f64(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> Result<FilterWeights<f64>, PicScaleError> {
+        <f32 as WeightsGenerator<f64>>::make_weights(resampling, in_size, out_size)
+    }
+
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f32; out_size * 4];
+                let mut dst_neon = vec![0f32; out_size * 4];
+                convolve_horizontal_native_row_f32_f64::<4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_neon_row_one_f32_f64(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON rgba f32/f64 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f64(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_neon = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_4_row_f32_f64::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_neon_rows_4_f32_f64(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_neon,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: NEON rgba f32/f64 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_u16.rs
+++ b/src/neon/rgba_u16.rs
@@ -338,3 +338,93 @@ fn convolve_horizontal_rgba_neon_f32_u16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_horizontal::{
+        convolve_row_handler_floating_point, convolve_row_handler_floating_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    // Dispatched only when bit_depth > 12 and RDM is unavailable - this path
+    // is floating-point internally despite storing u16 pixels, so the scalar
+    // reference is `floating_point_horizontal`, not the fixed-point handler.
+    const BIT_DEPTH: u32 = 16;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 4, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * 4];
+                let mut dst_neon = vec![0u16; out_size * 4];
+                convolve_row_handler_floating_point::<u16, f32, f32, 4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_neon_f32_u16_row(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, 4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_neon_rows_4_f32_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_u16_hb.rs
+++ b/src/neon/rgba_u16_hb.rs
@@ -398,3 +398,154 @@ fn convolve_horizontal_rgba_neon_u16_hb_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    const BIT_DEPTH: u32 = 16;
+
+    fn make_row_filter_weights_u16_q31(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> FilterWeights<i32> {
+        let weights_f32 = <u16 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation::<i32, 31>(0)
+    }
+
+    /// Scalar model of ARM's `SQRDMLAH`/`SQRDMULH`: `round(2*a*b / 2^32)`,
+    /// i.e. `round(a*b / 2^31)` - matches the `vqrdmlahq_s32` accumulation
+    /// used by the real NEON `_hb` kernels bit-for-bit for realistic inputs
+    /// (saturation only differs at the a=b=i32::MIN corner, unreachable here).
+    fn sqrdmulh(a: i32, b: i32) -> i32 {
+        let prod = 2i64 * (a as i64) * (b as i64) + (1i64 << 31);
+        (prod >> 32) as i32
+    }
+
+    fn scalar_ref_hb_row<const CN: usize>(
+        src: &[u16],
+        dst: &mut [u16],
+        filter_weights: &FilterWeights<i32>,
+        bit_depth: u32,
+    ) {
+        let max_colors = (1i32 << bit_depth) - 1;
+        for ((chunk, &bounds), weights) in dst
+            .as_chunks_mut::<CN>()
+            .0
+            .iter_mut()
+            .zip(filter_weights.bounds.iter())
+            .zip(
+                filter_weights
+                    .weights
+                    .chunks_exact(filter_weights.aligned_size),
+            )
+        {
+            let mut acc = [1i32 << 5; CN];
+            let px = bounds.start * CN;
+            let src_chunk = &src[px..(px + bounds.size * CN)];
+            for (&w, src_px) in weights[..bounds.size]
+                .iter()
+                .zip(src_chunk.as_chunks::<CN>().0.iter())
+            {
+                for c in 0..CN {
+                    let a = (src_px[c] as i32) << 6;
+                    acc[c] += sqrdmulh(a, w);
+                }
+            }
+            for c in 0..CN {
+                chunk[c] = (acc[c] >> 6).clamp(0, max_colors) as u16;
+            }
+        }
+    }
+
+    fn scalar_ref_hb_rows_4<const CN: usize>(
+        src: &[u16],
+        src_stride: usize,
+        dst: &mut [u16],
+        dst_stride: usize,
+        filter_weights: &FilterWeights<i32>,
+        bit_depth: u32,
+    ) {
+        let (row0, rest) = dst.split_at_mut(dst_stride);
+        let (row1, rest) = rest.split_at_mut(dst_stride);
+        let (row2, row3) = rest.split_at_mut(dst_stride);
+        for (row, offset) in [(row0, 0), (row1, src_stride), (row2, src_stride * 2), (row3, src_stride * 3)] {
+            scalar_ref_hb_row::<CN>(&src[offset..], row, filter_weights, bit_depth);
+        }
+    }
+
+    #[cfg(feature = "rdm")]
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights = make_row_filter_weights_u16_q31(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 4, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * 4];
+                let mut dst_neon = vec![0u16; out_size * 4];
+                scalar_ref_hb_row::<4>(&src, &mut dst_scalar, &filter_weights, BIT_DEPTH);
+                convolve_horizontal_rgba_neon_u16_hb_row(&src, &mut dst_neon, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON RDM single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "rdm")]
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights = make_row_filter_weights_u16_q31(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                scalar_ref_hb_rows_4::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_neon_rows_4_hb_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON RDM 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_u16_lb.rs
+++ b/src/neon/rgba_u16_lb.rs
@@ -305,3 +305,90 @@ pub(crate) fn convolve_horizontal_rgba_neon_u16_lb_row(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 4, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; out_size * 4];
+                let mut dst_neon = vec![0u16; out_size * 4];
+                convolve_row_handler_fixed_point::<u16, i32, 4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_neon_u16_lb_row(
+                    &src,
+                    &mut dst_neon,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_neon = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<u16, i32, 4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_neon_rows_4_lb_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_u8.rs
+++ b/src/neon/rgba_u8.rs
@@ -335,3 +335,81 @@ fn convolve_horizontal_rgba_neon_row_impl<const D: bool, const PRECISION: i32>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    // Same comparison as `src/sse/rgba_u8.rs` and `src/avx2/rgba_u8.rs`: the
+    // portable scalar fallback is the common ground truth every accelerated
+    // backend must agree with, on every architecture, which transitively
+    // means every backend must agree with every other backend too.
+
+    #[test]
+    fn neon_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 4);
+
+                let mut dst_scalar = vec![0u8; out_size * 4];
+                let mut dst_neon = vec![0u8; out_size * 4];
+                handle_fixed_row_u8::<4>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgba_neon_row(&src, &mut dst_neon, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_neon = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_neon_rows_4_u8(
+                    &src,
+                    src_stride,
+                    &mut dst_neon,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_neon,
+                    "{resampling:?} {in_size}->{out_size}: NEON 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_u8_dot.rs
+++ b/src/neon/rgba_u8_dot.rs
@@ -401,3 +401,118 @@ fn convolve_horizontal_rgba_neon_row_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    /// Same Q0.7 fixed-point reasoning as `rgb_u8_dot.rs`'s test module: the
+    /// i8mm dot-product path quantizes weights to Q0.7 rather than the Q15
+    /// `i16` weights the base NEON rgba path uses, so the scalar reference is
+    /// reimplemented directly against the same arithmetic `vusdotq_s32` +
+    /// `vqshrun_n_s32::<7>` + `vqmovn_u16` perform: an i32 accumulator per
+    /// channel with a rounding bias of `1 << 6`, then `>> 7`, clamped to `u8`.
+    fn scalar_reference_rgba_dot_row(src: &[u8], dst: &mut [u8], filter_weights: &FilterWeights<i8>) {
+        const CN: usize = 4;
+        const ROUNDING: i32 = 1 << 6;
+        for (dst_px, (&bounds, weights)) in dst.as_chunks_mut::<CN>().0.iter_mut().zip(
+            filter_weights
+                .bounds
+                .iter()
+                .zip(filter_weights.weights.chunks_exact(filter_weights.aligned_size)),
+        ) {
+            let mut acc = [ROUNDING; CN];
+            for k in 0..bounds.size {
+                let w = weights[k] as i32;
+                let src_px = &src[(bounds.start + k) * CN..];
+                for (c, acc_c) in acc.iter_mut().enumerate() {
+                    *acc_c += w * src_px[c] as i32;
+                }
+            }
+            for (c, dst_c) in dst_px.iter_mut().enumerate() {
+                *dst_c = (acc[c] >> 7).clamp(0, 255) as u8;
+            }
+        }
+    }
+
+    fn make_row_filter_weights_q0_7(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> FilterWeights<i8> {
+        let weights_f32 =
+            <u8 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation_q0_7(0)
+    }
+
+    #[test]
+    fn neon_dot_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("i8mm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights = make_row_filter_weights_q0_7(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 4);
+
+                let mut dst_scalar = vec![0u8; out_size * 4];
+                let mut dst_dot = vec![0u8; out_size * 4];
+                scalar_reference_rgba_dot_row(&src, &mut dst_scalar, &filter_weights);
+                convolve_horizontal_rgba_neon_row_dot(&src, &mut dst_dot, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_dot,
+                    "{resampling:?} {in_size}->{out_size}: NEON i8mm dot rgba single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_dot_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("i8mm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights = make_row_filter_weights_q0_7(resampling, in_size, out_size);
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_dot = vec![0u8; dst_stride * ROWS];
+                for row in 0..ROWS {
+                    scalar_reference_rgba_dot_row(
+                        &src[row * src_stride..],
+                        &mut dst_scalar[row * dst_stride..(row + 1) * dst_stride],
+                        &filter_weights,
+                    );
+                }
+                convolve_horizontal_rgba_neon_rows_4_u8_dot(
+                    &src,
+                    src_stride,
+                    &mut dst_dot,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_dot,
+                    "{resampling:?} {in_size}->{out_size}: NEON i8mm dot rgba 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/rgba_u8_rdm.rs
+++ b/src/neon/rgba_u8_rdm.rs
@@ -457,3 +457,148 @@ fn convolve_horizontal_rgba_neon_row_i16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    // Same `rdm` reasoning as `rgb_u8_sqrdml.rs`: two independent per-channel
+    // i16 accumulators (even-indexed taps in the low half, odd-indexed taps
+    // in the high half), each updated with the saturating rounding-doubling
+    // multiply-accumulate `vqrdmlahq_s16` performs - not a plain widening MAC,
+    // so it can't be modeled with the crate's usual i32-accumulator scalar
+    // reference. Unlike the RGB CN=3 path, this rgba (CN=4) path folds the two
+    // halves together (`vadd_s16(low, high)`) *before* accumulating a final
+    // odd leftover tap (via the narrower, non-`q` `vqrdmlah_s16`), rather than
+    // after - so the fold point differs and is reproduced exactly here.
+    fn expand8_to_14(x: u8) -> i16 {
+        (((x as u32) * 257) >> 2) as i16
+    }
+
+    fn sqrdmlah_i16(acc: i16, a: i16, b: i16) -> i16 {
+        let product2 = 2i64 * (a as i64) * (b as i64);
+        let rounded = (product2 + (1i64 << 15)) >> 16;
+        (acc as i64 + rounded).clamp(i16::MIN as i64, i16::MAX as i64) as i16
+    }
+
+    fn scalar_reference_rgba_rdm_row(
+        src: &[u8],
+        dst: &mut [u8],
+        filter_weights: &FilterWeights<i16>,
+    ) {
+        const CN: usize = 4;
+        const ROUNDING: i16 = 1 << 5;
+        for (dst_px, (&bounds, weights)) in dst.as_chunks_mut::<CN>().0.iter_mut().zip(
+            filter_weights
+                .bounds
+                .iter()
+                .zip(filter_weights.weights.chunks_exact(filter_weights.aligned_size)),
+        ) {
+            let mut low = [ROUNDING; CN];
+            let mut high = [0i16; CN];
+            let mut k = 0usize;
+            while k + 2 <= bounds.size {
+                let w0 = weights[k];
+                let w1 = weights[k + 1];
+                let src0 = &src[(bounds.start + k) * CN..];
+                let src1 = &src[(bounds.start + k + 1) * CN..];
+                for c in 0..CN {
+                    low[c] = sqrdmlah_i16(low[c], expand8_to_14(src0[c]), w0);
+                }
+                for c in 0..CN {
+                    high[c] = sqrdmlah_i16(high[c], expand8_to_14(src1[c]), w1);
+                }
+                k += 2;
+            }
+
+            let mut folded = [0i16; CN];
+            for c in 0..CN {
+                folded[c] = low[c].wrapping_add(high[c]);
+            }
+
+            if k < bounds.size {
+                let w = weights[k];
+                let src_last = &src[(bounds.start + k) * CN..];
+                for c in 0..CN {
+                    folded[c] = sqrdmlah_i16(folded[c], expand8_to_14(src_last[c]), w);
+                }
+            }
+
+            for c in 0..CN {
+                dst_px[c] = ((folded[c] >> 6) as i32).clamp(0, 255) as u8;
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rdm_row_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 4);
+
+                let mut dst_scalar = vec![0u8; out_size * 4];
+                let mut dst_rdm = vec![0u8; out_size * 4];
+                scalar_reference_rgba_rdm_row(&src, &mut dst_scalar, &filter_weights);
+                convolve_horizontal_rgba_neon_row_i16(&src, &mut dst_rdm, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_rdm,
+                    "{resampling:?} {in_size}->{out_size}: NEON rdm rgba single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn neon_rdm_rows_4_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_rdm = vec![0u8; dst_stride * ROWS];
+                for row in 0..ROWS {
+                    scalar_reference_rgba_rdm_row(
+                        &src[row * src_stride..],
+                        &mut dst_scalar[row * dst_stride..(row + 1) * dst_stride],
+                        &filter_weights,
+                    );
+                }
+                convolve_horizontal_rgba_neon_rows_4_u8_i16(
+                    &src,
+                    src_stride,
+                    &mut dst_rdm,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_rdm,
+                    "{resampling:?} {in_size}->{out_size}: NEON rdm rgba 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/neon/vertical_f16.rs
+++ b/src/neon/vertical_f16.rs
@@ -253,3 +253,86 @@ pub(crate) fn convolve_vertical_rgb_neon_row_f16(
         );
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::convolve_vertical_rgb_native_row_f16;
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // The scalar reference widens `f16` to `f32`, convolves, then narrows
+    // back; this backend does the same via native `vcvt_f32_f16`/
+    // `vcvt_f16_f32` but accumulates in 8/16/32-wide chunks, reordering
+    // relative to the scalar loop's strictly sequential multiply-then-add,
+    // so match the `1e-3` tolerance used by the existing f16 horizontal
+    // comparison tests (e.g. `neon/rgb_f16.rs`).
+    const ATOL: f32 = 1e-3;
+
+    #[test]
+    fn neon_f16_vertical_matches_scalar_reference() {
+        run_vertical_comparison(convolve_vertical_rgb_neon_row_f16, "NEON f16");
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_vertical_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[f16], &mut [f16], usize, &[f32], u32),
+        label: &str,
+    ) {
+        // Row widths chosen to be multiples of 1 (plane), 3 (rgb) and 4 (rgba)
+        // pixels, plus a couple of odd sizes so every SIMD tail-loop width
+        // (32/16/8/blended-remainder) gets exercised at least once.
+        const ROW_WIDTHS: [usize; 7] = [1, 3, 4, 39, 99, 160, 41];
+
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+
+                for &row_width in ROW_WIDTHS.iter() {
+                    let src_stride = row_width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE
+                            ^ (in_height as u64) << 32
+                            ^ (out_height as u64) << 16
+                            ^ row_width as u64,
+                    );
+                    let src = rng.fill_f16_unit(src_stride * in_height);
+
+                    for y in 0..out_height {
+                        let bounds = filter_weights.bounds[y];
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f16; row_width];
+                        let mut dst_simd = vec![0f16; row_width];
+
+                        convolve_vertical_rgb_native_row_f16(
+                            0,
+                            &bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        simd_fn(row_width, &bounds, &src, &mut dst_simd, src_stride, weights, 8);
+
+                        assert_f16_slices_close(
+                            &dst_simd,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {row_width}: {label}"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_f16_fhm.rs
+++ b/src/neon/vertical_f16_fhm.rs
@@ -333,3 +333,89 @@ fn convolve_vertical_rgb_neon_row_f16_impl(
         );
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::convolve_vertical_rgb_native_row_f16;
+    use crate::filter_weights::{WeightFloat16Converter, WeightsConverter};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // The `fhm` path widens f16 taps through `vfmlalq_low_f16`/`_high_f16`,
+    // which accumulate in f32 but the weights themselves are pre-quantized to
+    // f16 (via `WeightFloat16Converter`, the same conversion `f16.rs`'s
+    // vertical plan applies before dispatching here) - not bit-exact against
+    // the scalar f32-weighted reference, matching the horizontal fhm test in
+    // `rgb_f16_fhm.rs`.
+    const ATOL: f32 = 5e-2;
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn neon_fhm_vertical_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fhm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights_f32 =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+                let filter_weights_f16 =
+                    WeightFloat16Converter::default().prepare_weights(&filter_weights_f32);
+                let needed_rows = max_source_rows_needed(&filter_weights_f32.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_f16_unit(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights_f32.bounds.iter().enumerate() {
+                        let filter_offset_f32 = y * filter_weights_f32.aligned_size;
+                        let weights_f32 = &filter_weights_f32.weights[filter_offset_f32..];
+                        let filter_offset_f16 = y * filter_weights_f16.aligned_size;
+                        let weights_f16 = &filter_weights_f16.weights[filter_offset_f16..];
+
+                        let mut dst_scalar = vec![0f16; width];
+                        let mut dst_neon = vec![0f16; width];
+                        convolve_vertical_rgb_native_row_f16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights_f32,
+                            8,
+                        );
+                        convolve_vertical_rgb_neon_row_f16_fhm(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_neon,
+                            src_stride,
+                            weights_f16,
+                            8,
+                        );
+
+                        assert_f16_slices_close(
+                            &dst_neon,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON fhm vertical"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_f16_full.rs
+++ b/src/neon/vertical_f16_full.rs
@@ -263,3 +263,83 @@ fn xconvolve_vertical_rgb_neon_row_f16_impl(
         );
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::convolve_vertical_rgb_native_row_f16;
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // The "full" fp16 path accumulates natively in f16 (`vfmaq_f16`), which
+    // has far fewer significand bits than the scalar f32 accumulation used by
+    // `convolve_vertical_rgb_native_row_f16` (the same scalar fallback
+    // `f16.rs`'s vertical plan uses) - not bit-exact, and needs a looser
+    // tolerance, matching the horizontal fp16 test in `rgb_f16_full.rs`.
+    const ATOL: f32 = 5e-2;
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn neon_fp16_vertical_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_f16_unit(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f16; width];
+                        let mut dst_neon = vec![0f16; width];
+                        convolve_vertical_rgb_native_row_f16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        xconvolve_vertical_rgb_neon_row_f16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_neon,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+
+                        assert_f16_slices_close(
+                            &dst_neon,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON fp16 vertical"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_f32.rs
+++ b/src/neon/vertical_f32.rs
@@ -369,3 +369,85 @@ pub(crate) fn convolve_vertical_rgb_neon_row_f32(
         cx += 1;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_vertical::column_handler_floating_point;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // NEON has no runtime feature detection (it's baseline on aarch64) and
+    // uses `vfmaq_laneq_f32`/`prefer_vfmaq_f32`, fusing multiply+add per lane
+    // in the same accumulation order as the scalar loop, so this is expected
+    // to be bit-exact (start from 0.0, per the task's guidance, before
+    // reaching for a tolerance).
+    const ATOL: f32 = 0.0;
+
+    #[test]
+    fn neon_vertical_matches_scalar_reference() {
+        run_vertical_comparison(convolve_vertical_rgb_neon_row_f32, "NEON");
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_vertical_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[f32], &mut [f32], usize, &[f32], u32),
+        label: &str,
+    ) {
+        // Row widths chosen to be multiples of 1 (plane), 3 (rgb) and 4 (rgba)
+        // pixels, plus a couple of odd sizes so every SIMD tail-loop width
+        // (32/16/8/4/1 lanes) gets exercised at least once.
+        const ROW_WIDTHS: [usize; 7] = [1, 3, 4, 39, 99, 160, 41];
+
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+
+                for &row_width in ROW_WIDTHS.iter() {
+                    let src_stride = row_width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE
+                            ^ (in_height as u64) << 32
+                            ^ (out_height as u64) << 16
+                            ^ row_width as u64,
+                    );
+                    let src = rng.fill_f32_unit(src_stride * in_height);
+
+                    for y in 0..out_height {
+                        let bounds = filter_weights.bounds[y];
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f32; row_width];
+                        let mut dst_simd = vec![0f32; row_width];
+
+                        column_handler_floating_point::<f32, f32, f32>(
+                            0,
+                            &bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        simd_fn(row_width, &bounds, &src, &mut dst_simd, src_stride, weights, 8);
+
+                        assert_f32_slices_close(
+                            &dst_simd,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {row_width}: {label}"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_f32_f64.rs
+++ b/src/neon/vertical_f32_f64.rs
@@ -247,3 +247,86 @@ pub(crate) fn convolve_vertical_neon_row_f32_f64(
         cx += 1;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_vertical::column_handler_floating_point;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    // `PreferQuality` path: weights and the accumulator are both `f64`. NEON
+    // has no runtime feature detection here and accumulates lanes in the
+    // same sequential order as the scalar loop, so bit-exact output is
+    // expected (start from 0.0 per the task's guidance).
+    const ATOL: f32 = 0.0;
+
+    #[test]
+    fn neon_f64_vertical_matches_scalar_reference() {
+        run_vertical_comparison(convolve_vertical_neon_row_f32_f64, "NEON f64");
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_vertical_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[f32], &mut [f32], usize, &[f64], u32),
+        label: &str,
+    ) {
+        // Row widths chosen to be multiples of 1 (plane), 3 (rgb) and 4 (rgba)
+        // pixels, plus a couple of odd sizes so every SIMD tail-loop width
+        // (16/8/4/1 lanes) gets exercised at least once.
+        const ROW_WIDTHS: [usize; 7] = [1, 3, 4, 39, 99, 160, 41];
+
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    <f32 as WeightsGenerator<f64>>::make_weights(resampling, in_height, out_height)
+                        .unwrap();
+
+                for &row_width in ROW_WIDTHS.iter() {
+                    let src_stride = row_width;
+                    let mut rng = XorShiftRng::new(
+                        0xBADF00D
+                            ^ (in_height as u64) << 32
+                            ^ (out_height as u64) << 16
+                            ^ row_width as u64,
+                    );
+                    let src = rng.fill_f32_unit(src_stride * in_height);
+
+                    for y in 0..out_height {
+                        let bounds = filter_weights.bounds[y];
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f32; row_width];
+                        let mut dst_simd = vec![0f32; row_width];
+
+                        column_handler_floating_point::<f32, f64, f64>(
+                            0,
+                            &bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        simd_fn(row_width, &bounds, &src, &mut dst_simd, src_stride, weights, 8);
+
+                        assert_f32_slices_close(
+                            &dst_simd,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {row_width}: {label}"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_s16_hb.rs
+++ b/src/neon/vertical_s16_hb.rs
@@ -333,3 +333,111 @@ fn convolve_column_hb_s16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::filter_weights::FilterWeights;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    // Signed-`i16` counterpart of `src/neon/vertical_u16_hb.rs`: see that
+    // file's test module for why a bespoke scalar reference is needed here
+    // (this Q31 accumulator path is not covered by `column_handler_fixed_point`).
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    fn fill_i16(rng: &mut XorShiftRng, len: usize) -> Vec<i16> {
+        rng.fill_u16(len, u16::MAX).into_iter().map(|v| v as i16).collect()
+    }
+
+    fn make_hb_weights(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> FilterWeights<i32> {
+        let weights_f32 =
+            <i16 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation::<i32, 31>(0)
+    }
+
+    fn scalar_hb_reference(
+        bounds: &FilterBounds,
+        src: &[i16],
+        dst: &mut [i16],
+        src_stride: usize,
+        weight: &[i32],
+        bit_depth: u32,
+    ) {
+        let max_colors = (1i64 << (bit_depth - 1)) - 1;
+        let min_colors = -(1i64 << (bit_depth - 1));
+        const R: i64 = 1 << 30;
+        for (x, d) in dst.iter_mut().enumerate() {
+            let mut acc: i64 = 0;
+            for (j, &w) in weight[..bounds.size].iter().enumerate() {
+                let py = bounds.start + j;
+                acc += src[src_stride * py + x] as i64 * w as i64;
+            }
+            *d = ((acc + R) >> 31).max(min_colors).min(max_colors) as i16;
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn neon_vertical_hb_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const BIT_DEPTH: u32 = 16;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights = make_hb_weights(resampling, in_height, out_height);
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = fill_i16(&mut rng, src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0i16; width];
+                        let mut dst_neon = vec![0i16; width];
+                        scalar_hb_reference(
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_column_hb_s16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_neon,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_neon,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON vertical hb (s16) output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_s16_lb.rs
+++ b/src/neon/vertical_s16_lb.rs
@@ -373,3 +373,78 @@ pub(crate) fn convolve_column_lb_i16(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_vertical::column_handler_fixed_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    // Signed-`i16` counterpart of `src/neon/vertical_u16_lb.rs`: the
+    // accelerated low-bit-depth (<=12 bit) fixed-point path must agree
+    // bit-for-bit with `column_handler_fixed_point::<i16, i32>`, the scalar
+    // reference `ImageStore<i16, 1>::vertical_plan` falls back to.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    fn fill_i16(rng: &mut XorShiftRng, len: usize) -> Vec<i16> {
+        rng.fill_u16(len, u16::MAX).into_iter().map(|v| v as i16).collect()
+    }
+
+    #[test]
+    fn neon_vertical_lb_matches_scalar_reference() {
+        const BIT_DEPTH: u32 = 12;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = fill_i16(&mut rng, src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0i16; width];
+                        let mut dst_neon = vec![0i16; width];
+                        column_handler_fixed_point::<i16, i32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_column_lb_i16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_neon,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_neon,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON vertical lb (s16) output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_u16.rs
+++ b/src/neon/vertical_u16.rs
@@ -188,3 +188,79 @@ pub(crate) fn convolve_column_u16(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_vertical::column_handler_floating_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    // This is the base/high-bit-depth (>12 bit) NEON column path, which
+    // `factory/plane_u16.rs`'s `default_u16_column_plan` falls back to for
+    // bit depths above 12 whenever neither the `rdm` nor `sve` fast paths are
+    // taken. For that same bit-depth range, the non-NEON fallback in the same
+    // function is `column_handler_floating_point::<u16, f32, f32>` - both
+    // accumulate in `f32` with real (non-quantized) weights, so that's the
+    // correct scalar reference here (same as `sse/vertical_u16.rs`'s test).
+    const BIT_DEPTH: u32 = 16;
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn neon_vertical_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src =
+                        rng.fill_u16(src_stride * needed_rows, ((1u32 << BIT_DEPTH) - 1) as u16);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u16; width];
+                        let mut dst_neon = vec![0u16; width];
+                        column_handler_floating_point::<u16, f32, f32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_column_u16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_neon,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_neon,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON vertical (16-bit) output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_u16_hb.rs
+++ b/src/neon/vertical_u16_hb.rs
@@ -347,3 +347,113 @@ fn convolve_column_hb_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::filter_weights::FilterWeights;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    // `convolve_column_hb_u16` is the fixed-point vertical path used for
+    // >12-bit-depth `u16` pixels on NEON when the `rdm` feature is available
+    // (see `default_u16_column_plan` in `src/factory/plane_u16.rs`). It uses
+    // a bespoke Q31 accumulator (not the crate-wide `PRECISION`=15 used by
+    // `column_handler_fixed_point`), so there is no existing generic scalar
+    // reference for it. The scalar reference below is copied verbatim from
+    // this same file's own tail-element loop (the `store0 += ...; (store0 +
+    // (1 << 30)) >> 31` formula a few lines up), which is the most precise
+    // - and therefore authoritative - path the accelerated function itself
+    // falls back to for elements that don't fill a SIMD lane.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    fn make_hb_weights(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> FilterWeights<i32> {
+        let weights_f32 =
+            <u16 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation::<i32, 31>(0)
+    }
+
+    fn scalar_hb_reference(
+        bounds: &FilterBounds,
+        src: &[u16],
+        dst: &mut [u16],
+        src_stride: usize,
+        weight: &[i32],
+        bit_depth: u32,
+    ) {
+        let max_colors = (1u32 << bit_depth) - 1;
+        const R: i64 = 1 << 30;
+        for (x, d) in dst.iter_mut().enumerate() {
+            let mut acc: i64 = 0;
+            for (j, &w) in weight[..bounds.size].iter().enumerate() {
+                let py = bounds.start + j;
+                acc += src[src_stride * py + x] as i64 * w as i64;
+            }
+            *d = ((acc + R) >> 31).max(0).min(max_colors as i64) as u16;
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn neon_vertical_hb_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        const BIT_DEPTH: u32 = 16;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights = make_hb_weights(resampling, in_height, out_height);
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u16(src_stride * needed_rows, (1u16 << 15) - 1);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u16; width];
+                        let mut dst_neon = vec![0u16; width];
+                        scalar_hb_reference(
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_column_hb_u16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_neon,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_neon,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON vertical hb output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_u16_lb.rs
+++ b/src/neon/vertical_u16_lb.rs
@@ -589,3 +589,74 @@ pub(crate) fn convolve_column_lb_u16(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_vertical::column_handler_fixed_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    // Same idea as the u8 vertical tests in `src/neon/vertical_u8.rs`: for
+    // every output row the accelerated low-bit-depth (<=12 bit) fixed-point
+    // path must agree bit-for-bit with `column_handler_fixed_point::<u16, i32>`,
+    // the same scalar reference `default_u16_column_plan` falls back to.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn neon_vertical_lb_matches_scalar_reference() {
+        const BIT_DEPTH: u32 = 12;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u16(src_stride * needed_rows, (1u16 << BIT_DEPTH) - 1);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u16; width];
+                        let mut dst_neon = vec![0u16; width];
+                        column_handler_fixed_point::<u16, i32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_column_lb_u16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_neon,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_neon,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON vertical lb output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_u8.rs
+++ b/src/neon/vertical_u8.rs
@@ -411,3 +411,75 @@ fn convolve_vertical_neon_row_full<const D: bool, const PRECISION: i32>(
         convolve_items::<D, PRECISION>(rem, bounds, src, src_stride, weight, cx);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::handle_fixed_column_u8;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    // Same idea as the horizontal backend-comparison tests (see
+    // `src/neon/rgba_u8.rs`), but for the vertical (column) pass. Only the
+    // standard `PRECISION`-15 path is covered here; the `rdm`/`i8mm` variants
+    // in `vertical_u8_rdm.rs`/`vertical_u8_dot.rs` use different accumulator
+    // precisions and are intentionally left uncovered by this bit-exact
+    // comparison, matching how the horizontal tests treat those files too.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn neon_vertical_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[13usize, 131usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u8(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u8; width];
+                        let mut dst_neon = vec![0u8; width];
+                        handle_fixed_column_u8(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        convolve_vertical_neon_i32_precision(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_neon,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_neon,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON vertical output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_u8_dot.rs
+++ b/src/neon/vertical_u8_dot.rs
@@ -513,3 +513,97 @@ fn convolve_vertical_neon_row_upper(
     rem = rem.as_chunks_mut::<8>().1;
     convolve_items(rem, bounds, src, src_stride, weight, cx);
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+    use crate::test_utils::XorShiftRng;
+
+    // Same Q0.7 reasoning as the horizontal i8mm dot files (`rgb_u8_dot.rs`,
+    // `rgba_u8_dot.rs`): weights are quantized to Q0.7 `i8`, and the
+    // accumulation is a genuine widening i32 dot product (`vusdotq_s32`) with
+    // a single final saturating narrow, so it's safe to model directly with
+    // an i32 accumulator: rounding bias `1 << 6`, then `>> 7`, clamped to
+    // `u8`.
+    fn scalar_reference_vertical_dot(
+        bounds: &FilterBounds,
+        src: &[u8],
+        dst: &mut [u8],
+        src_stride: usize,
+        weight: &[i8],
+    ) {
+        const ROUNDING: i32 = 1 << 6;
+        for (x, dst_x) in dst.iter_mut().enumerate() {
+            let mut acc = ROUNDING;
+            for (k, &w) in weight.iter().take(bounds.size).enumerate() {
+                let py = bounds.start + k;
+                acc += w as i32 * src[src_stride * py + x] as i32;
+            }
+            *dst_x = (acc >> 7).clamp(0, 255) as u8;
+        }
+    }
+
+    fn make_row_filter_weights_q0_7(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> crate::filter_weights::FilterWeights<i8> {
+        let weights_f32 =
+            <u8 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation_q0_7(0)
+    }
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn neon_dot_vertical_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("i8mm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights = make_row_filter_weights_q0_7(resampling, in_height, out_height);
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[13usize, 131usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u8(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u8; width];
+                        let mut dst_dot = vec![0u8; width];
+                        scalar_reference_vertical_dot(
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                        );
+                        convolve_vertical_neon_i8_dot(
+                            width, bounds, &src, &mut dst_dot, src_stride, weights, 8,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_dot,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON i8mm dot vertical output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/neon/vertical_u8_rdm.rs
+++ b/src/neon/vertical_u8_rdm.rs
@@ -490,3 +490,100 @@ fn convolve_vertical_neon_row_upper(
     rem = rem.as_chunks_mut::<8>().1;
     convolve_items(rem, bounds, src, src_stride, weight, cx);
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    // Unlike the horizontal `rdm` paths, the vertical one applies
+    // `vqrdmlahq_s16`/`vqrdmlah_lane_s16` to every output column
+    // independently and sequentially (each tap updates every column's
+    // accumulator once, in increasing tap order - there's no low/high
+    // even/odd-tap interleaving trick here), so this is a straightforward
+    // per-column fold: widen each byte to the same 14-bit fixed
+    // representation `expand8_to_14` uses (`(byte * 257) >> 2`), fold in each
+    // tap with the saturating rounding-doubling-multiply-accumulate formula
+    // RDM uses, then `>> 6` and clamp to `u8`.
+    fn expand8_to_14(x: u8) -> i16 {
+        (((x as u32) * 257) >> 2) as i16
+    }
+
+    fn sqrdmlah_i16(acc: i16, a: i16, b: i16) -> i16 {
+        let product2 = 2i64 * (a as i64) * (b as i64);
+        let rounded = (product2 + (1i64 << 15)) >> 16;
+        (acc as i64 + rounded).clamp(i16::MIN as i64, i16::MAX as i64) as i16
+    }
+
+    fn scalar_reference_vertical_rdm(
+        bounds: &FilterBounds,
+        src: &[u8],
+        dst: &mut [u8],
+        src_stride: usize,
+        weight: &[i16],
+    ) {
+        const ROUNDING: i16 = 1 << 5;
+        for (x, dst_x) in dst.iter_mut().enumerate() {
+            let mut store = ROUNDING;
+            for (k, &w) in weight.iter().take(bounds.size).enumerate() {
+                let py = bounds.start + k;
+                store = sqrdmlah_i16(store, expand8_to_14(src[src_stride * py + x]), w);
+            }
+            *dst_x = ((store >> 6) as i32).clamp(0, 255) as u8;
+        }
+    }
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn neon_rdm_vertical_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("rdm") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[13usize, 131usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u8(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u8; width];
+                        let mut dst_rdm = vec![0u8; width];
+                        scalar_reference_vertical_rdm(
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                        );
+                        convolve_vertical_neon_i16_precision(
+                            width, bounds, &src, &mut dst_rdm, src_stride, weights, 8,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_rdm,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: NEON rdm vertical output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sse/alpha_f16.rs
+++ b/src/sse/alpha_f16.rs
@@ -200,3 +200,80 @@ fn sse_unpremultiply_alpha_rgba_f16_row_impl<const F16C: bool>(in_place: &mut [f
         unpremultiply_pixel_f16_row(rem);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close};
+
+    // f16 has only ~10 bits of mantissa, so the f32-domain rounding
+    // differences between the scalar reference and the SSE (f16<->f32
+    // conversion + multiply/divide) path can move the result by roughly one
+    // f16 ULP. Random alpha is kept away from 0 (see `make_rgba`) so
+    // unpremultiply's relative error stays small in absolute terms too.
+    const ATOL: f32 = 1e-3;
+
+    /// Builds an RGBA f16 buffer in `[0, 1)` that mixes alpha == 0, alpha == 1
+    /// and fully random pixels (with random alpha kept away from 0) so both
+    /// the vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<f16> {
+        let mut buf = rng.fill_f16_unit(pixels * 4);
+        for chunk in buf.as_chunks_mut::<4>().0 {
+            chunk[3] = (0.05 + 0.95 * chunk[3] as f32) as f16;
+        }
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0.;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 1.;
+        }
+        buf
+    }
+
+    #[test]
+    fn sse_premultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0f16; pixels * 4];
+            let mut dst_sse = vec![0f16; pixels * 4];
+            premultiply_pixel_f16_row(&mut dst_scalar, &src);
+            sse_premultiply_alpha_rgba_f16(&mut dst_sse, &src);
+
+            assert_f16_slices_close(
+                &dst_sse,
+                &dst_scalar,
+                ATOL,
+                &format!("{pixels} pixels: SSE premultiply"),
+            );
+        }
+    }
+
+    #[test]
+    fn sse_unpremultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut sse_buf = src;
+            unpremultiply_pixel_f16_row(&mut scalar_buf);
+            sse_unpremultiply_alpha_rgba_f16(&mut sse_buf);
+
+            assert_f16_slices_close(
+                &sse_buf,
+                &scalar_buf,
+                ATOL,
+                &format!("{pixels} pixels: SSE unpremultiply"),
+            );
+        }
+    }
+}

--- a/src/sse/alpha_f32.rs
+++ b/src/sse/alpha_f32.rs
@@ -121,3 +121,85 @@ fn sse_premultiply_alpha_rgba_f32_row_impl(dst: &mut [f32], src: &[f32]) {
         premultiply_rgba_f32_row(rem, src_rem);
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close};
+
+    // Premultiply is a plain per-lane multiply with no reassociation, so it
+    // is bit-exact against the scalar reference. Unpremultiply is not: the
+    // scalar reference computes `1. / a` and then multiplies, while SSE does
+    // a direct `_mm_div_ps(x, a)` - mathematically the same but rounded
+    // differently, so it can be off by a few ULPs. Since alpha is kept away
+    // from 0 (see `make_rgba`) that relative error stays small in absolute
+    // terms too.
+    const ATOL: f32 = 1e-4;
+
+    /// Builds an RGBA f32 buffer in `[0, 1)` that mixes alpha == 0, alpha == 1
+    /// and fully random pixels so both the vectorized bulk path and the
+    /// scalar tail remainder exercise every branch the
+    /// premultiply/unpremultiply math takes on alpha. Random alpha is kept
+    /// away from 0 (but still far from 1) so that unpremultiplying does not
+    /// blow up the relative rounding error between the direct SSE division
+    /// and the scalar reciprocal-then-multiply into a huge absolute one.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<f32> {
+        let mut buf = rng.fill_f32_unit(pixels * 4);
+        for chunk in buf.as_chunks_mut::<4>().0 {
+            chunk[3] = 0.05 + 0.95 * chunk[3];
+        }
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0.;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 1.;
+        }
+        buf
+    }
+
+    #[test]
+    fn sse_premultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0f32; pixels * 4];
+            let mut dst_sse = vec![0f32; pixels * 4];
+            premultiply_rgba_f32_row(&mut dst_scalar, &src);
+            sse_premultiply_alpha_rgba_f32(&mut dst_sse, &src);
+
+            assert_f32_slices_close(
+                &dst_sse,
+                &dst_scalar,
+                ATOL,
+                &format!("{pixels} pixels: SSE premultiply"),
+            );
+        }
+    }
+
+    #[test]
+    fn sse_unpremultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut sse_buf = src;
+            unpremultiply_rgba_f32_row(&mut scalar_buf);
+            sse_unpremultiply_alpha_rgba_f32(&mut sse_buf);
+
+            assert_f32_slices_close(
+                &sse_buf,
+                &scalar_buf,
+                ATOL,
+                &format!("{pixels} pixels: SSE unpremultiply"),
+            );
+        }
+    }
+}

--- a/src/sse/alpha_u16.rs
+++ b/src/sse/alpha_u16.rs
@@ -425,3 +425,73 @@ fn premultiply_alpha_sse_rgba_u16_row_impl(dst: &mut [u16], src: &[u16], bit_dep
         pma_sse41_rgba16_dispatch(dst, src, bit_depth, Sse41PremultiplyExecutorAny::default())
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::alpha_handle_u16::{premultiply_alpha_rgba_row, unpremultiply_alpha_rgba_row};
+    use crate::test_utils::XorShiftRng;
+
+    /// Builds an RGBA16 buffer (values clamped to `bit_depth`) that mixes
+    /// alpha == 0, alpha == max and fully random pixels, so both the
+    /// vectorized bulk path and the scalar tail remainder exercise every
+    /// branch the premultiply/unpremultiply math takes on alpha.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize, bit_depth: usize) -> Vec<u16> {
+        let max_colors = ((1u32 << bit_depth) - 1) as u16;
+        let mut buf = rng.fill_u16(pixels * 4, max_colors);
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = max_colors;
+        }
+        buf
+    }
+
+    #[test]
+    fn sse_premultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for bit_depth in [10usize, 12, 16, 14] {
+            for pixels in [1usize, 4, 17, 256] {
+                let mut rng = XorShiftRng::new(0xA11CE ^ (bit_depth as u64) << 32 ^ pixels as u64);
+                let src = make_rgba(&mut rng, pixels, bit_depth);
+
+                let mut dst_scalar = vec![0u16; pixels * 4];
+                let mut dst_sse = vec![0u16; pixels * 4];
+                premultiply_alpha_rgba_row(&mut dst_scalar, &src, bit_depth);
+                premultiply_alpha_sse_rgba_u16(&mut dst_sse, &src, bit_depth);
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "bit_depth {bit_depth}, {pixels} pixels: SSE premultiply diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, only reproducible when compiled without FMA (e.g. CI's isolated no-FMA jobs) - see issue"]
+    #[test]
+    fn sse_unpremultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for bit_depth in [10usize, 12, 16, 14] {
+            for pixels in [1usize, 4, 17, 256] {
+                let mut rng = XorShiftRng::new(0xB0BA ^ (bit_depth as u64) << 32 ^ pixels as u64);
+                let src = make_rgba(&mut rng, pixels, bit_depth);
+
+                let mut scalar_buf = src.clone();
+                let mut sse_buf = src;
+                unpremultiply_alpha_rgba_row(&mut scalar_buf, bit_depth);
+                unpremultiply_alpha_sse_rgba_u16(&mut sse_buf, bit_depth);
+
+                assert_eq!(
+                    scalar_buf, sse_buf,
+                    "bit_depth {bit_depth}, {pixels} pixels: SSE unpremultiply diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/sse/alpha_u8.rs
+++ b/src/sse/alpha_u8.rs
@@ -309,3 +309,72 @@ fn sse_unpremultiply_alpha_rgba_impl_row(in_place: &mut [u8], executor: impl Dis
 fn sse_unpremultiply_alpha_rgba_impl(in_place: &mut [u8]) {
     sse_unpremultiply_alpha_rgba_impl_row(in_place, DisassociateAlphaDefault::default());
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::WorkloadStrategy;
+    use crate::alpha_handle_u8::{
+        premultiply_alpha_rgba_row_impl, unpremultiply_alpha_rgba_row_impl,
+    };
+    use crate::test_utils::XorShiftRng;
+
+    /// Builds an RGBA8 buffer that cycles through the alpha edge cases the
+    /// premultiply/unpremultiply math branches on (alpha == 0, alpha == 255)
+    /// in addition to fully random pixels, so both the vectorized bulk path
+    /// and the scalar tail remainder see all three cases.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<u8> {
+        let mut buf = rng.fill_u8(pixels * 4);
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 255;
+        }
+        buf
+    }
+
+    #[ignore = "known bug: div_by_255 rounding formula uses +127 instead of +128 on one term, diverges from the scalar reference for part of the u8*u8 product range - see issue"]
+    #[test]
+    fn sse_premultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0u8; pixels * 4];
+            let mut dst_sse = vec![0u8; pixels * 4];
+            premultiply_alpha_rgba_row_impl(&mut dst_scalar, &src);
+            sse_premultiply_alpha_rgba(&mut dst_sse, &src);
+
+            assert_eq!(
+                dst_scalar, dst_sse,
+                "{pixels} pixels: SSE premultiply diverges from the scalar reference"
+            );
+        }
+    }
+
+    #[ignore = "known bug: uses an approximate reciprocal (_mm_rcp_ps/_mm256_rcp_ps) instead of exact division like the scalar reference - see issue"]
+    #[test]
+    fn sse_unpremultiply_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut sse_buf = src;
+            unpremultiply_alpha_rgba_row_impl(&mut scalar_buf);
+            sse_unpremultiply_alpha_rgba(&mut sse_buf, WorkloadStrategy::PreferSpeed);
+
+            assert_eq!(
+                scalar_buf, sse_buf,
+                "{pixels} pixels: SSE unpremultiply diverges from the scalar reference"
+            );
+        }
+    }
+}

--- a/src/sse/cbcr8.rs
+++ b/src/sse/cbcr8.rs
@@ -371,3 +371,82 @@ fn convolve_horizontal_cbcr_sse_row_one_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 2);
+
+                let mut dst_scalar = vec![0u8; out_size * 2];
+                let mut dst_sse = vec![0u8; out_size * 2];
+                handle_fixed_row_u8::<2>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_cbcr_sse_row_one(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE cbcr single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 2;
+                let dst_stride = out_size * 2;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_sse = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<2>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_cbcr_sse_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE cbcr 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/sse/plane_f32.rs
+++ b/src/sse/plane_f32.rs
@@ -379,3 +379,95 @@ fn convolve_horizontal_plane_sse_rows_4_impl<const FMA: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{
+        convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32,
+    };
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // Unlike rgba_f32.rs (one channel per SIMD lane, no intra-lane reduction),
+    // a single-channel plane accumulates multiple taps within the same lane
+    // and needs a horizontal reduction, reordering the sum vs the scalar
+    // loop's strict left-to-right accumulation - not bit-exact (observed diffs
+    // are a single f32 ULP).
+    const ATOL: f32 = 1e-5;
+
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size);
+
+                let mut dst_scalar = vec![0f32; out_size];
+                let mut dst_sse = vec![0f32; out_size];
+                convolve_horizontal_native_row_f32::<1>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_plane_sse_row_one(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE plane f32 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_sse = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_plane_sse_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE plane f32 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/sse/plane_u8.rs
+++ b/src/sse/plane_u8.rs
@@ -289,3 +289,82 @@ fn convolve_horizontal_plane_sse_row_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size);
+
+                let mut dst_scalar = vec![0u8; out_size];
+                let mut dst_sse = vec![0u8; out_size];
+                handle_fixed_row_u8::<1>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_plane_sse_row(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE plane single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size;
+                let dst_stride = out_size;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_sse = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<1>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_plane_sse_rows_4_u8(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE plane 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/sse/rgb_f16.rs
+++ b/src/sse/rgb_f16.rs
@@ -467,3 +467,98 @@ fn convolve_horizontal_rgb_sse_rows_4_f16_impl<const F16C: bool, const FMA: bool
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // SSE dispatches to the F16C=false/FMA=false path here regardless of runtime
+    // detection, so this only reorders the multiply-then-add relative to the
+    // scalar loop's strictly sequential accumulation - not bit-exact.
+    const ATOL: f32 = 1e-3;
+
+    #[ignore = "known bug: SSE f32->f16 fallback conversion (_mm_cvtps_ph_fallback) drops the sign bit, so negative resampling kernel taps (e.g. Lanczos3) round-trip as positive - see issue"]
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f16; out_size * 3];
+                let mut dst_sse = vec![0f16; out_size * 3];
+                convolve_horizontal_rgb_native_row_f16::<3>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_sse_row_one_f16(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_f16_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE rgb f16 single-row"),
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: SSE f32->f16 fallback conversion (_mm_cvtps_ph_fallback) drops the sign bit, so negative resampling kernel taps (e.g. Lanczos3) round-trip as positive - see issue"]
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_sse = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_sse_rows_4_f16(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE rgb f16 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/sse/rgb_f32.rs
+++ b/src/sse/rgb_f32.rs
@@ -412,3 +412,90 @@ impl<const FMA: bool> ExecutionUnit4Row<FMA> {
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32};
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // Bit-exact vs the scalar reference: this SSE path uses plain multiply+add
+    // (no FMA), accumulated tap-by-tap in the same order as the scalar loop.
+    const ATOL: f32 = 0.0;
+
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 3);
+
+                let mut dst_scalar = vec![0f32; out_size * 3];
+                let mut dst_sse = vec![0f32; out_size * 3];
+                convolve_horizontal_native_row_f32::<3>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgb_sse_row_one_f32(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE RGB f32 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_sse = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_sse_rows_4_f32(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE RGB f32 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/sse/rgb_u8.rs
+++ b/src/sse/rgb_u8.rs
@@ -343,3 +343,82 @@ fn convolve_horizontal_rgb_sse_row_one_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 3);
+
+                let mut dst_scalar = vec![0u8; out_size * 3];
+                let mut dst_sse = vec![0u8; out_size * 3];
+                handle_fixed_row_u8::<3>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgb_sse_row_one(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE RGB single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_sse = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_sse_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE RGB 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/sse/rgba_f16.rs
+++ b/src/sse/rgba_f16.rs
@@ -391,3 +391,98 @@ fn convolve_horizontal_rgba_sse_rows_4_f16_regular(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::{convolve_horizontal_rgb_native_row_f16, convolve_horizontal_rgba_4_row_f16};
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // SSE dispatches to the F16C=false/FMA=false path here regardless of runtime
+    // detection, so this only reorders the multiply-then-add relative to the
+    // scalar loop's strictly sequential accumulation - not bit-exact.
+    const ATOL: f32 = 1e-3;
+
+    #[ignore = "known bug: SSE f32->f16 fallback conversion (_mm_cvtps_ph_fallback) drops the sign bit, so negative resampling kernel taps (e.g. Lanczos3) round-trip as positive - see issue"]
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f16_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f16; out_size * 4];
+                let mut dst_sse = vec![0f16; out_size * 4];
+                convolve_horizontal_rgb_native_row_f16::<4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_sse_row_one_f16(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_f16_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE f16 single-row"),
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: SSE f32->f16 fallback conversion (_mm_cvtps_ph_fallback) drops the sign bit, so negative resampling kernel taps (e.g. Lanczos3) round-trip as positive - see issue"]
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f16_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f16; dst_stride * ROWS];
+                let mut dst_sse = vec![0f16; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f16::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_sse_rows_4_f16(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f16_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE f16 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/sse/rgba_f32.rs
+++ b/src/sse/rgba_f32.rs
@@ -386,3 +386,88 @@ fn convolve_horizontal_rgba_sse_rows_4_f32_impl<const FMA: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::convolve_naive_f32::{convolve_horizontal_native_row_f32, convolve_horizontal_rgba_4_row_f32};
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    const ATOL: f32 = 0.0;
+
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_f32_unit(in_size * 4);
+
+                let mut dst_scalar = vec![0f32; out_size * 4];
+                let mut dst_sse = vec![0f32; out_size * 4];
+                convolve_horizontal_native_row_f32::<4>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgba_sse_row_one_f32(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_f32_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE f32 single-row"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_f32_unit(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0f32; dst_stride * ROWS];
+                let mut dst_sse = vec![0f32; dst_stride * ROWS];
+                convolve_horizontal_rgba_4_row_f32::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_sse_rows_4_f32(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_f32_slices_close(
+                    &dst_sse,
+                    &dst_scalar,
+                    ATOL,
+                    &format!("{resampling:?} {in_size}->{out_size}: SSE f32 4-row"),
+                );
+            }
+        }
+    }
+}

--- a/src/sse/rgba_u16.rs
+++ b/src/sse/rgba_u16.rs
@@ -461,3 +461,93 @@ fn convolve_horizontal_rgba_sse_u16_row_impl<const FMA: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_horizontal::{
+        convolve_row_handler_floating_point, convolve_row_handler_floating_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    const BIT_DEPTH: u32 = 16;
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 4, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; out_size * 4];
+                let mut dst_sse = vec![0u16; out_size * 4];
+                convolve_row_handler_floating_point::<u16, f32, f32, 4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_sse_u16_row(&src, &mut dst_sse, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u16(src_stride * ROWS, u16::MAX);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_sse = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_floating_point_4::<u16, f32, f32, 4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_sse_rows_4_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/sse/rgba_u16_lb.rs
+++ b/src/sse/rgba_u16_lb.rs
@@ -401,3 +401,91 @@ fn convolve_horizontal_rgba_sse_u16_lb_row_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_horizontal::{
+        convolve_row_handler_fixed_point, convolve_row_handler_fixed_point_4,
+    };
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    const BIT_DEPTH: u32 = 10;
+
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u16(in_size * 4, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; out_size * 4];
+                let mut dst_sse = vec![0u16; out_size * 4];
+                convolve_row_handler_fixed_point::<u16, i32, 4>(
+                    &src,
+                    &mut dst_scalar,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_sse_u16_lb_row(&src, &mut dst_sse, &filter_weights, BIT_DEPTH);
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u16(src_stride * ROWS, (1u16 << BIT_DEPTH) - 1);
+
+                let mut dst_scalar = vec![0u16; dst_stride * ROWS];
+                let mut dst_sse = vec![0u16; dst_stride * ROWS];
+                convolve_row_handler_fixed_point_4::<u16, i32, 4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+                convolve_horizontal_rgba_sse_rows_4_lb_u16(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    BIT_DEPTH,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/sse/rgba_u8.rs
+++ b/src/sse/rgba_u8.rs
@@ -356,3 +356,82 @@ fn convolve_horizontal_rgba_sse_rows_one_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    #[test]
+    fn sse_row_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 4);
+
+                let mut dst_scalar = vec![0u8; out_size * 4];
+                let mut dst_sse = vec![0u8; out_size * 4];
+                handle_fixed_row_u8::<4>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgba_sse_rows_one(&src, &mut dst_sse, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sse_rows_4_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_sse = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_sse_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_sse,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_sse,
+                    "{resampling:?} {in_size}->{out_size}: SSE 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/sse/vertical_f16.rs
+++ b/src/sse/vertical_f16.rs
@@ -298,3 +298,103 @@ fn convolve_vertical_sse_row_f16_impl<const FMA: bool, const F16C: bool>(
         cx += 1;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::f16::convolve_vertical_rgb_native_row_f16;
+    use crate::test_utils::{XorShiftRng, assert_f16_slices_close, make_row_filter_weights_f32};
+
+    // Same reasoning as the AVX2 f16 vertical comparison: the scalar
+    // reference round-trips through `f32`, this backend accumulates in
+    // 8/16-wide chunks and always uses a software `f16` conversion fallback
+    // (`convolve_vertical_sse_row_f16_regular` instantiates `F16C = false`),
+    // and the result is narrowed back to `f16`, so match the `1e-3`
+    // tolerance used by the existing f16 horizontal comparison tests.
+    const ATOL: f32 = 1e-3;
+
+    // KNOWN BUG (found by this test, not fixed here per task instructions):
+    // `_mm_cvtps_ph_fallback` in `src/sse/f16_utils.rs` never ORs the sign
+    // bit into its result - it builds the packed `f16` purely from `j1 | j2
+    // | sat`, none of which touch the input's sign. Every SSE f16 path that
+    // instantiates `F16C = false` (which both this vertical entry point and
+    // the horizontal ones in `sse/rgba_f16.rs`/`sse/rgb_f16.rs` do
+    // unconditionally, regardless of runtime `f16c` support) silently
+    // converts any negative accumulator to its positive magnitude before
+    // storing. Lanczos weights have negative side lobes, so this reliably
+    // reproduces once enough resampling/height/width combinations are
+    // tried - e.g. `Lanczos3 64->37 row 15 width 39: SSE f16: index 14:
+    // 0.06384277 vs -0.06384277 (diff 0.12768555 > atol 0.001)`. This test
+    // is intentionally left failing to document the bug.
+    #[ignore = "known bug: SSE f32->f16 fallback conversion (_mm_cvtps_ph_fallback) drops the sign bit, so negative resampling kernel taps (e.g. Lanczos3) round-trip as positive - see issue"]
+    #[test]
+    fn sse_f16_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        run_vertical_comparison(convolve_vertical_sse_row_f16, "SSE f16");
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_vertical_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[f16], &mut [f16], usize, &[f32], u32),
+        label: &str,
+    ) {
+        // Row widths chosen to be multiples of 1 (plane), 3 (rgb) and 4 (rgba)
+        // pixels, plus a couple of odd sizes so every SIMD tail-loop width
+        // (16/8/4/1 lanes) gets exercised at least once.
+        const ROW_WIDTHS: [usize; 7] = [1, 3, 4, 39, 99, 160, 41];
+
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+
+                for &row_width in ROW_WIDTHS.iter() {
+                    let src_stride = row_width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE
+                            ^ (in_height as u64) << 32
+                            ^ (out_height as u64) << 16
+                            ^ row_width as u64,
+                    );
+                    let src = rng.fill_f16_unit(src_stride * in_height);
+
+                    for y in 0..out_height {
+                        let bounds = filter_weights.bounds[y];
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f16; row_width];
+                        let mut dst_simd = vec![0f16; row_width];
+
+                        convolve_vertical_rgb_native_row_f16(
+                            0,
+                            &bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        simd_fn(row_width, &bounds, &src, &mut dst_simd, src_stride, weights, 8);
+
+                        assert_f16_slices_close(
+                            &dst_simd,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {row_width}: {label}"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sse/vertical_f32.rs
+++ b/src/sse/vertical_f32.rs
@@ -335,3 +335,87 @@ fn convolve_vertical_rgb_sse_row_f32_impl<const FMA: bool>(
         cx += 1;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_vertical::column_handler_floating_point;
+    use crate::test_utils::{XorShiftRng, assert_f32_slices_close, make_row_filter_weights_f32};
+
+    // SSE only has a single dispatch path here (no runtime FMA selection - see
+    // `convolve_vertical_rgb_sse_row_f32_regular` always instantiating
+    // `FMA = false`), and each lane accumulates one weighted row at a time in
+    // the same order as the scalar loop, so this backend is bit-exact.
+    const ATOL: f32 = 0.0;
+
+    #[test]
+    fn sse_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        run_vertical_comparison(convolve_vertical_rgb_sse_row_f32, "SSE");
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_vertical_comparison(
+        simd_fn: fn(usize, &FilterBounds, &[f32], &mut [f32], usize, &[f32], u32),
+        label: &str,
+    ) {
+        // Row widths chosen to be multiples of 1 (plane), 3 (rgb) and 4 (rgba)
+        // pixels, plus a couple of odd sizes so every SIMD tail-loop width
+        // (24/16/8/4/1 lanes) gets exercised at least once.
+        const ROW_WIDTHS: [usize; 7] = [1, 3, 4, 39, 99, 160, 41];
+
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+
+                for &row_width in ROW_WIDTHS.iter() {
+                    let src_stride = row_width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE
+                            ^ (in_height as u64) << 32
+                            ^ (out_height as u64) << 16
+                            ^ row_width as u64,
+                    );
+                    let src = rng.fill_f32_unit(src_stride * in_height);
+
+                    for y in 0..out_height {
+                        let bounds = filter_weights.bounds[y];
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0f32; row_width];
+                        let mut dst_simd = vec![0f32; row_width];
+
+                        column_handler_floating_point::<f32, f32, f32>(
+                            0,
+                            &bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        simd_fn(row_width, &bounds, &src, &mut dst_simd, src_stride, weights, 8);
+
+                        assert_f32_slices_close(
+                            &dst_simd,
+                            &dst_scalar,
+                            ATOL,
+                            &format!(
+                                "{resampling:?} {in_height}->{out_height} row {y} width {row_width}: {label}"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sse/vertical_u16.rs
+++ b/src/sse/vertical_u16.rs
@@ -233,3 +233,81 @@ fn convolve_column_lb_u16_impl<const FMA: bool>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::floating_point_vertical::column_handler_floating_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_f32};
+
+    // Unlike vertical_u16_lb.rs (<=12 bit, exact fixed-point), this is the
+    // high-bit-depth (>12 bit, e.g. 16-bit) path: both this SIMD function and
+    // its scalar reference (`column_handler_floating_point::<u16, f32, f32>`,
+    // what `factory/plane_u16.rs` falls back to for this bit-depth range)
+    // accumulate in `f32` with real (non-quantized) weights.
+    const BIT_DEPTH: u32 = 16;
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference, reproducible with Lanczos3 (negative-weight) kernels - see issue"]
+    #[test]
+    fn sse_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_f32(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src =
+                        rng.fill_u16(src_stride * needed_rows, ((1u32 << BIT_DEPTH) - 1) as u16);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u16; width];
+                        let mut dst_sse = vec![0u16; width];
+                        column_handler_floating_point::<u16, f32, f32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_column_sse_u16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_sse,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_sse,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: SSE vertical (16-bit) output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sse/vertical_u16_lb.rs
+++ b/src/sse/vertical_u16_lb.rs
@@ -214,3 +214,77 @@ fn convolve_column_lb_u16_impl(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_vertical::column_handler_fixed_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    // Same idea as the u8 vertical tests in `src/sse/vertical_u8.rs`: for
+    // every output row the accelerated low-bit-depth (<=12 bit) fixed-point
+    // path must agree bit-for-bit with `column_handler_fixed_point::<u16, i32>`,
+    // the same scalar reference `default_u16_column_plan` falls back to.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn sse_vertical_lb_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        const BIT_DEPTH: u32 = 12;
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u16(src_stride * needed_rows, (1u16 << BIT_DEPTH) - 1);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u16; width];
+                        let mut dst_sse = vec![0u16; width];
+                        column_handler_fixed_point::<u16, i32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_column_lb_sse_u16(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_sse,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_sse,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: SSE vertical lb output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sse/vertical_u8.rs
+++ b/src/sse/vertical_u8.rs
@@ -357,3 +357,76 @@ fn convolve_vertical_sse_row_impl(
         cx += 1;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::handle_fixed_column_u8;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    // Same idea as the horizontal backend-comparison tests (see
+    // `src/sse/rgba_u8.rs`), but for the vertical (column) pass: for every
+    // output row the accelerated function must agree bit-for-bit with the
+    // portable fixed-point scalar fallback given identical weights and bounds.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn sse_vertical_matches_scalar_reference() {
+        if !is_x86_feature_detected!("sse4.1") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[13usize, 131usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u8(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u8; width];
+                        let mut dst_sse = vec![0u8; width];
+                        handle_fixed_column_u8(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        convolve_vertical_sse_row(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_sse,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_sse,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: SSE vertical output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sve2/rgb_u8_dot.rs
+++ b/src/sve2/rgb_u8_dot.rs
@@ -251,3 +251,127 @@ fn convolve_horizontal_rgb_neon_row_one_impl_dot(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+
+    /// This SVE2/i8mm dot-product path quantizes weights to Q7 (`i8`, see
+    /// `filter_weights.numerical_approximation_q0_7(0)` at its `factory/rgb_u8.rs`
+    /// dispatch site) instead of the crate's usual Q15 (`i16`) - a different
+    /// precision than `handler_provider`'s scalar reference, so that can't be
+    /// reused directly. Rebuild the same Q7 fixed-point math by hand.
+    fn scalar_reference_rgb_q7_row(src: &[u8], dst: &mut [u8], filter_weights: &FilterWeights<i8>) {
+        const PRECISION: i32 = 7;
+        const ROUNDING: i32 = 1 << (PRECISION - 1);
+        const CN: usize = 3;
+
+        for (dst_chunk, (&bounds, weights)) in dst.as_chunks_mut::<CN>().0.iter_mut().zip(
+            filter_weights
+                .bounds
+                .iter()
+                .zip(filter_weights.weights.chunks_exact(filter_weights.aligned_size)),
+        ) {
+            let mut acc = [ROUNDING; CN];
+            for (k, &weight) in weights.iter().enumerate().take(bounds.size) {
+                let w = weight as i32;
+                let px = (bounds.start + k) * CN;
+                for c in 0..CN {
+                    acc[c] += src[px + c] as i32 * w;
+                }
+            }
+            for c in 0..CN {
+                dst_chunk[c] = (acc[c] >> PRECISION).clamp(0, 255) as u8;
+            }
+        }
+    }
+
+    fn make_q7_weights(
+        resampling: ResamplingFunction,
+        in_size: usize,
+        out_size: usize,
+    ) -> FilterWeights<i8> {
+        let weights_f32 =
+            <u8 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size).unwrap();
+        weights_f32.numerical_approximation_q0_7(0)
+    }
+
+    #[test]
+    fn sve2_row_matches_scalar_reference() {
+        if !(std::arch::is_aarch64_feature_detected!("sve2")
+            && std::arch::is_aarch64_feature_detected!("i8mm"))
+        {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights = make_q7_weights(resampling, in_size, out_size);
+                let mut rng = crate::test_utils::XorShiftRng::new(
+                    0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64,
+                );
+                let src = rng.fill_u8(in_size * 3);
+
+                let mut dst_scalar = vec![0u8; out_size * 3];
+                let mut dst_sve = vec![0u8; out_size * 3];
+                scalar_reference_rgb_q7_row(&src, &mut dst_scalar, &filter_weights);
+                sve_convolve_horizontal_rgb_neon_row_one_dot(&src, &mut dst_sve, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_sve,
+                    "{resampling:?} {in_size}->{out_size}: SVE2 dot single-row output diverges from the Q7 scalar reference"
+                );
+            }
+        }
+    }
+
+    #[ignore = "known bug: rows 1-3 of the 4-row batch produce a degenerate repeated-value pattern (R=G=B, same sequence repeated) instead of real per-row output - likely a lane/stride bug in the SVE2 dot-product kernel - see issue"]
+    #[test]
+    fn sve2_rows_4_matches_scalar_reference() {
+        if !(std::arch::is_aarch64_feature_detected!("sve2")
+            && std::arch::is_aarch64_feature_detected!("i8mm"))
+        {
+            return;
+        }
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights = make_q7_weights(resampling, in_size, out_size);
+                let mut rng = crate::test_utils::XorShiftRng::new(
+                    0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64,
+                );
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_sve = vec![0u8; dst_stride * ROWS];
+                for row in 0..ROWS {
+                    scalar_reference_rgb_q7_row(
+                        &src[row * src_stride..],
+                        &mut dst_scalar[row * dst_stride..(row + 1) * dst_stride],
+                        &filter_weights,
+                    );
+                }
+                sve_convolve_horizontal_rgb_neon_rows_4_dot(
+                    &src,
+                    src_stride,
+                    &mut dst_sve,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_sve,
+                    "{resampling:?} {in_size}->{out_size}: SVE2 dot 4-row output diverges from the Q7 scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/sve2/vertical_u16_dot.rs
+++ b/src/sve2/vertical_u16_dot.rs
@@ -549,3 +549,82 @@ fn convolve_vertical_sve2_u16_row(
         cx += vl;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::fixed_point_vertical::column_handler_fixed_point;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u16};
+
+    // Unlike the Q7-quantized rgb_u8_dot.rs/vertical_u8_dot.rs SVE2 paths,
+    // this one uses standard Q15 (`i16`) weights - see
+    // `DefaultWeightsConverter::prepare_weights` at its
+    // `factory/plane_u16.rs` dispatch site (`bit_depth` in `(12, 15]`) - so
+    // the usual `column_handler_fixed_point::<u16, i32>` scalar reference
+    // applies directly, same as `sse/vertical_u16_lb.rs`.
+    const BIT_DEPTH: u32 = 14;
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[ignore = "known bug: small (+/-1) fixed-point rounding divergence from the scalar reference - see issue"]
+    #[test]
+    fn sve2_vertical_matches_scalar_reference() {
+        if !std::arch::is_aarch64_feature_detected!("sve2") {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u16(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src =
+                        rng.fill_u16(src_stride * needed_rows, ((1u32 << BIT_DEPTH) - 1) as u16);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u16; width];
+                        let mut dst_sve = vec![0u16; width];
+                        column_handler_fixed_point::<u16, i32>(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+                        convolve_vertical_sve2_u16_dot(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_sve,
+                            src_stride,
+                            weights,
+                            BIT_DEPTH,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_sve,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: SVE2 u16 dot vertical output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sve2/vertical_u8_dot.rs
+++ b/src/sve2/vertical_u8_dot.rs
@@ -550,3 +550,101 @@ fn convolve_vertical_sve2_row(
         cx += vl;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::math::WeightsGenerator;
+
+    // Same Q7 rationale as sve2/rgb_u8_dot.rs: this path quantizes weights to
+    // `i8` (see `filter_weights.numerical_approximation_q0_7(0)` at its
+    // `factory/rgb_u8.rs` vertical dispatch site), a different precision than
+    // the crate's usual Q15 scalar reference, so hand-roll the Q7 vertical
+    // math instead. Vertical convolution treats the row as flat elements
+    // (channels don't interact), matching `column_handler_fixed_point`'s
+    // own `width` semantics.
+    fn scalar_reference_q7_column(
+        width: usize,
+        bounds: &FilterBounds,
+        src: &[u8],
+        dst: &mut [u8],
+        src_stride: usize,
+        weight: &[i8],
+    ) {
+        const PRECISION: i32 = 7;
+        const ROUNDING: i32 = 1 << (PRECISION - 1);
+        for (x, dst) in dst.iter_mut().enumerate().take(width) {
+            let mut acc = ROUNDING;
+            for (j, &w) in weight.iter().enumerate().take(bounds.size) {
+                let py = bounds.start + j;
+                acc += src[src_stride * py + x] as i32 * w as i32;
+            }
+            *dst = (acc >> PRECISION).clamp(0, 255) as u8;
+        }
+    }
+
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn sve2_vertical_matches_scalar_reference() {
+        if !(std::arch::is_aarch64_feature_detected!("sve2")
+            && std::arch::is_aarch64_feature_detected!("i8mm"))
+        {
+            return;
+        }
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let weights_f32 =
+                    <u8 as WeightsGenerator<f32>>::make_weights(resampling, in_height, out_height)
+                        .unwrap();
+                let filter_weights = weights_f32.numerical_approximation_q0_7(0);
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[9usize, 53usize] {
+                    let src_stride = width;
+                    let mut rng = crate::test_utils::XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u8(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u8; width];
+                        let mut dst_sve = vec![0u8; width];
+                        scalar_reference_q7_column(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                        );
+                        convolve_vertical_sve2_i8_dot(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_sve,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_sve,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: SVE2 dot vertical output diverges from the Q7 scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Radzivon Bartoshyk. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+//! Shared harness for cross-backend differential tests: every accelerated
+//! (SSE/AVX2/AVX-512/NEON/SVE2/WASM) row-convolution function is built to the
+//! same signature as the portable scalar fallback in `handler_provider`, so
+//! feeding both the identical weights and source pixels and diffing the
+//! outputs catches a backend that has drifted from the others - regardless of
+//! which architecture the test suite happens to run on.
+#![cfg(test)]
+
+use crate::filter_weights::FilterWeights;
+use crate::math::WeightsGenerator;
+use crate::support::PRECISION;
+use crate::{PicScaleError, ResamplingFunction};
+#[cfg(feature = "nightly_f16")]
+use core::f16;
+
+/// Builds the same fixed-point row filter weights the real resize pipeline
+/// would use for `u8` horizontal convolution, so backend-comparison tests
+/// exercise realistic weight patterns instead of ad-hoc synthetic ones.
+pub(crate) fn make_row_filter_weights_u8(
+    resampling: ResamplingFunction,
+    in_size: usize,
+    out_size: usize,
+) -> Result<FilterWeights<i16>, PicScaleError> {
+    let weights_f32 = <u8 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size)?;
+    Ok(weights_f32.numerical_approximation::<i16, PRECISION>(0))
+}
+
+/// Builds the real (non-quantized) `f32` row filter weights the floating-point
+/// pipeline uses directly - no fixed-point conversion involved. Also the
+/// correct weights to use for `f16` convolution: that pipeline weights in
+/// `FilterWeights<f32>` too (only the pixel storage type is `f16`).
+pub(crate) fn make_row_filter_weights_f32(
+    resampling: ResamplingFunction,
+    in_size: usize,
+    out_size: usize,
+) -> Result<FilterWeights<f32>, PicScaleError> {
+    <f32 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size)
+}
+
+/// Same as `make_row_filter_weights_u8`, but for `u16` fixed-point convolution
+/// (still quantized to `i16` weights - `u16` pixels just carry more bit depth).
+pub(crate) fn make_row_filter_weights_u16(
+    resampling: ResamplingFunction,
+    in_size: usize,
+    out_size: usize,
+) -> Result<FilterWeights<i16>, PicScaleError> {
+    let weights_f32 = <u16 as WeightsGenerator<f32>>::make_weights(resampling, in_size, out_size)?;
+    Ok(weights_f32.numerical_approximation::<i16, PRECISION>(0))
+}
+
+/// Minimal dependency-free xorshift64 PRNG so backend-comparison tests are
+/// reproducible without pulling in a `rand` dev-dependency.
+pub(crate) struct XorShiftRng(u64);
+
+impl XorShiftRng {
+    pub(crate) fn new(seed: u64) -> Self {
+        XorShiftRng(seed | 1)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+
+    pub(crate) fn fill_u8(&mut self, len: usize) -> Vec<u8> {
+        (0..len).map(|_| (self.next_u64() % 256) as u8).collect()
+    }
+
+    /// Uniform `f32` in `[0, 1)`, the conventional range for normalized pixel data.
+    pub(crate) fn fill_f32_unit(&mut self, len: usize) -> Vec<f32> {
+        (0..len)
+            .map(|_| (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32)
+            .collect()
+    }
+
+    pub(crate) fn fill_u16(&mut self, len: usize, max_value: u16) -> Vec<u16> {
+        (0..len)
+            .map(|_| (self.next_u64() % (max_value as u64 + 1)) as u16)
+            .collect()
+    }
+
+    /// Uniform `f16` in `[0, 1)` - built from the same unit-`f32` stream so the
+    /// two are drawn from equivalent distributions, then narrowed to `f16`.
+    #[cfg(feature = "nightly_f16")]
+    pub(crate) fn fill_f16_unit(&mut self, len: usize) -> Vec<f16> {
+        self.fill_f32_unit(len)
+            .into_iter()
+            .map(|v| v as f16)
+            .collect()
+    }
+}
+
+/// Floating-point backends legitimately differ from the scalar reference by a
+/// few ULPs (different accumulation order under vectorization), so exact
+/// equality is the wrong check - unlike the fixed-point `u8` paths, where
+/// integer arithmetic must be bit-exact across every backend.
+pub(crate) fn assert_f32_slices_close(actual: &[f32], expected: &[f32], atol: f32, context: &str) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{context}: length mismatch ({} vs {})",
+        actual.len(),
+        expected.len()
+    );
+    for (i, (&a, &e)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (a - e).abs();
+        assert!(
+            diff <= atol,
+            "{context}: index {i}: {a} vs {e} (diff {diff} > atol {atol})"
+        );
+    }
+}
+
+/// Same idea as `assert_f32_slices_close`, comparing `f16` values by widening
+/// to `f32` first (fp16 has no ergonomic arithmetic ops on its own here).
+#[cfg(feature = "nightly_f16")]
+pub(crate) fn assert_f16_slices_close(
+    actual: &[f16],
+    expected: &[f16],
+    atol: f32,
+    context: &str,
+) {
+    let actual_f32: Vec<f32> = actual.iter().map(|&v| v as f32).collect();
+    let expected_f32: Vec<f32> = expected.iter().map(|&v| v as f32).collect();
+    assert_f32_slices_close(&actual_f32, &expected_f32, atol, context);
+}

--- a/src/wasm32/alpha_u8.rs
+++ b/src/wasm32/alpha_u8.rs
@@ -141,3 +141,64 @@ fn wasm_premultiply_alpha_rgba_impl(dst: &mut [u8], src: &[u8]) {
 
     premultiply_alpha_rgba_row_impl(rem, src_rem);
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::alpha_handle_u8::unpremultiply_alpha_rgba_row_impl;
+    use crate::test_utils::XorShiftRng;
+
+    /// Builds an RGBA8 buffer that mixes alpha == 0, alpha == 255 and fully
+    /// random pixels so both the vectorized bulk path and the scalar tail
+    /// remainder exercise the branches the premultiply/unpremultiply math
+    /// takes on alpha.
+    ///
+    /// Note: these tests are compile-checked only (see task notes) - wasm32
+    /// has no runtime installed on the x86_64 host that authored them.
+    fn make_rgba(rng: &mut XorShiftRng, pixels: usize) -> Vec<u8> {
+        let mut buf = rng.fill_u8(pixels * 4);
+        if let Some(chunk) = buf.first_chunk_mut::<4>() {
+            chunk[3] = 0;
+        }
+        if pixels > 1 {
+            buf[4 + 3] = 255;
+        }
+        buf
+    }
+
+    #[test]
+    fn wasm_premultiply_matches_scalar_reference() {
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xA11CE ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut dst_scalar = vec![0u8; pixels * 4];
+            let mut dst_wasm = vec![0u8; pixels * 4];
+            premultiply_alpha_rgba_row_impl(&mut dst_scalar, &src);
+            wasm_premultiply_alpha_rgba(&mut dst_wasm, &src);
+
+            assert_eq!(
+                dst_scalar, dst_wasm,
+                "{pixels} pixels: WASM premultiply diverges from the scalar reference"
+            );
+        }
+    }
+
+    #[test]
+    fn wasm_unpremultiply_matches_scalar_reference() {
+        for pixels in [1usize, 4, 17, 256] {
+            let mut rng = XorShiftRng::new(0xB0BA ^ pixels as u64);
+            let src = make_rgba(&mut rng, pixels);
+
+            let mut scalar_buf = src.clone();
+            let mut wasm_buf = src;
+            unpremultiply_alpha_rgba_row_impl(&mut scalar_buf);
+            wasm_unpremultiply_alpha_rgba(&mut wasm_buf, WorkloadStrategy::PreferSpeed);
+
+            assert_eq!(
+                scalar_buf, wasm_buf,
+                "{pixels} pixels: WASM unpremultiply diverges from the scalar reference"
+            );
+        }
+    }
+}

--- a/src/wasm32/rgb_u8.rs
+++ b/src/wasm32/rgb_u8.rs
@@ -294,3 +294,78 @@ fn convolve_horizontal_rgb_neon_row_one_impl<const PRECISION: i32>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    /// Note: these tests are compile-checked only (see task notes) - wasm32
+    /// has no runtime installed on the x86_64 host that authored them.
+    #[test]
+    fn wasm_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 3);
+
+                let mut dst_scalar = vec![0u8; out_size * 3];
+                let mut dst_wasm = vec![0u8; out_size * 3];
+                handle_fixed_row_u8::<3>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgb_wasm_row_one(&src, &mut dst_wasm, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_wasm,
+                    "{resampling:?} {in_size}->{out_size}: WASM single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wasm_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 3;
+                let dst_stride = out_size * 3;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_wasm = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<3>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgb_wasm_rows_4(
+                    &src,
+                    src_stride,
+                    &mut dst_wasm,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_wasm,
+                    "{resampling:?} {in_size}->{out_size}: WASM 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/wasm32/rgba_u8.rs
+++ b/src/wasm32/rgba_u8.rs
@@ -276,3 +276,78 @@ fn convolve_horizontal_rgba_wasm_row_impl<const PRECISION: i32>(
         }
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::{handle_fixed_row_u8, handle_fixed_rows_4_u8};
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    /// Note: these tests are compile-checked only (see task notes) - wasm32
+    /// has no runtime installed on the x86_64 host that authored them.
+    #[test]
+    fn wasm_row_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64), (256, 256), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xC0FFEE ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src = rng.fill_u8(in_size * 4);
+
+                let mut dst_scalar = vec![0u8; out_size * 4];
+                let mut dst_wasm = vec![0u8; out_size * 4];
+                handle_fixed_row_u8::<4>(&src, &mut dst_scalar, &filter_weights, 8);
+                convolve_horizontal_rgba_wasm_row(&src, &mut dst_wasm, &filter_weights, 8);
+
+                assert_eq!(
+                    dst_scalar, dst_wasm,
+                    "{resampling:?} {in_size}->{out_size}: WASM single-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wasm_rows_4_matches_scalar_reference() {
+        const ROWS: usize = 4;
+        for resampling in [ResamplingFunction::Bilinear, ResamplingFunction::Lanczos3] {
+            for (in_size, out_size) in [(64usize, 37usize), (37, 64)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_size, out_size).unwrap();
+                let mut rng = XorShiftRng::new(0xBADF00D ^ (in_size as u64) << 32 ^ out_size as u64);
+                let src_stride = in_size * 4;
+                let dst_stride = out_size * 4;
+                let src = rng.fill_u8(src_stride * ROWS);
+
+                let mut dst_scalar = vec![0u8; dst_stride * ROWS];
+                let mut dst_wasm = vec![0u8; dst_stride * ROWS];
+                handle_fixed_rows_4_u8::<4>(
+                    &src,
+                    src_stride,
+                    &mut dst_scalar,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+                convolve_horizontal_rgba_wasm_rows_4_u8(
+                    &src,
+                    src_stride,
+                    &mut dst_wasm,
+                    dst_stride,
+                    &filter_weights,
+                    8,
+                );
+
+                assert_eq!(
+                    dst_scalar, dst_wasm,
+                    "{resampling:?} {in_size}->{out_size}: WASM 4-row output diverges from the scalar reference"
+                );
+            }
+        }
+    }
+}

--- a/src/wasm32/vertical_u8.rs
+++ b/src/wasm32/vertical_u8.rs
@@ -344,3 +344,76 @@ fn convolve_vertical_neon_row_impl(
         cx += 1;
     }
 }
+
+#[cfg(test)]
+mod backend_comparison_tests {
+    use super::*;
+    use crate::ResamplingFunction;
+    use crate::handler_provider::handle_fixed_column_u8;
+    use crate::test_utils::{XorShiftRng, make_row_filter_weights_u8};
+
+    // Same idea as the horizontal backend-comparison tests (see
+    // `src/wasm32/rgba_u8.rs`), but for the vertical (column) pass: for every
+    // output row the accelerated function must agree bit-for-bit with the
+    // portable fixed-point scalar fallback given identical weights and bounds.
+    //
+    // Note: these tests are compile-checked only (see task notes) - wasm32
+    // has no runtime installed on the x86_64 host that authored them.
+    fn max_source_rows_needed(bounds: &[FilterBounds]) -> usize {
+        bounds.iter().map(|b| b.start + b.size).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn wasm_vertical_matches_scalar_reference() {
+        for resampling in [
+            ResamplingFunction::Bilinear,
+            ResamplingFunction::Lanczos3,
+            ResamplingFunction::Nearest,
+        ] {
+            for (in_height, out_height) in [(64usize, 37usize), (37, 64), (5, 3)] {
+                let filter_weights =
+                    make_row_filter_weights_u8(resampling, in_height, out_height).unwrap();
+                let needed_rows = max_source_rows_needed(&filter_weights.bounds);
+
+                for &width in &[13usize, 131usize] {
+                    let src_stride = width;
+                    let mut rng = XorShiftRng::new(
+                        0xC0FFEE ^ (in_height as u64) << 32 ^ (out_height as u64) << 16 ^ width as u64,
+                    );
+                    let src = rng.fill_u8(src_stride * needed_rows);
+
+                    for (y, bounds) in filter_weights.bounds.iter().enumerate() {
+                        let filter_offset = y * filter_weights.aligned_size;
+                        let weights = &filter_weights.weights[filter_offset..];
+
+                        let mut dst_scalar = vec![0u8; width];
+                        let mut dst_wasm = vec![0u8; width];
+                        handle_fixed_column_u8(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_scalar,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+                        wasm_vertical_neon_row(
+                            width,
+                            bounds,
+                            &src,
+                            &mut dst_wasm,
+                            src_stride,
+                            weights,
+                            8,
+                        );
+
+                        assert_eq!(
+                            dst_scalar, dst_wasm,
+                            "{resampling:?} {in_height}->{out_height} row {y} width {width}: WASM vertical output diverges from the scalar reference"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since I temporarily had no idea what to do with my AI tokens, I decided to revisit this project. While going through it, I noticed that it has relatively few tests. It seemed to me that, at the most basic level, the test logic could verify whether SIMD and non-SIMD implementations return the same results. As it turns out, they currently don't.

36 new tests are failing, and 1 crash was also discovered(I will create separate issue for them) - they are ignored in this PR

Also new PR added justfile, to check items with miri, and there are some problems

All tests were created by AI